### PR TITLE
feat: scaffold Scala module — data model, KV storage, placeholder UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+build/
+*.o
+*.so
+*.dylib
+*.dll
+moc_*
+*.user
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile.cmake
+result
+.direnv/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,99 @@
+cmake_minimum_required(VERSION 3.16)
+project(scala VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# ── Qt6 ───────────────────────────────────────────────────────────────────────
+find_package(Qt6 REQUIRED COMPONENTS Core Qml)
+
+set(CMAKE_AUTOMOC ON)
+
+# ── Logos SDK + liblogos ──────────────────────────────────────────────────────
+set(LOGOS_CPP_SDK_ROOT "" CACHE PATH "Path to logos-cpp-sdk install")
+set(LOGOS_LIBLOGOS_ROOT "" CACHE PATH "Path to logos-liblogos install")
+
+if(NOT "${LOGOS_CPP_SDK_ROOT}" STREQUAL "" AND NOT "${LOGOS_LIBLOGOS_ROOT}" STREQUAL "")
+    set(LOGOS_CORE_AVAILABLE ON)
+
+    add_library(logos_cpp_sdk INTERFACE)
+    target_include_directories(logos_cpp_sdk INTERFACE
+        "${LOGOS_LIBLOGOS_ROOT}/include"
+        "${LOGOS_CPP_SDK_ROOT}/include"
+        "${LOGOS_CPP_SDK_ROOT}/include/cpp"
+        "${LOGOS_CPP_SDK_ROOT}/include/core"
+    )
+
+    add_library(logos_core SHARED IMPORTED)
+    set_target_properties(logos_core PROPERTIES
+        IMPORTED_LOCATION "${LOGOS_LIBLOGOS_ROOT}/lib/liblogos_core.so"
+    )
+
+    find_library(LOGOS_SDK_LIB logos_sdk PATHS "${LOGOS_CPP_SDK_ROOT}/lib" NO_DEFAULT_PATH REQUIRED)
+endif()
+
+# ── Plugin target ─────────────────────────────────────────────────────────────
+qt_add_plugin(scala_plugin CLASS_NAME LogosCalendar)
+set_target_properties(scala_plugin PROPERTIES
+    PREFIX ""
+    OUTPUT_NAME "scala_plugin"
+)
+
+target_sources(scala_plugin PRIVATE
+    src/calendar_module.cpp
+    src/calendar_store.cpp
+    src/plugin.cpp
+)
+
+target_include_directories(scala_plugin PRIVATE src ${CMAKE_SOURCE_DIR})
+
+target_link_libraries(scala_plugin PRIVATE
+    Qt6::Core
+    Qt6::Qml
+)
+
+if(LOGOS_CORE_AVAILABLE)
+    find_package(Qt6 REQUIRED COMPONENTS RemoteObjects)
+    target_link_libraries(scala_plugin PRIVATE
+        Qt6::RemoteObjects
+        logos_cpp_sdk
+        logos_core
+        ${LOGOS_SDK_LIB}
+    )
+    target_compile_definitions(scala_plugin PRIVATE LOGOS_CORE_AVAILABLE)
+endif()
+
+# ── Compile definitions ──────────────────────────────────────────────────────
+target_compile_definitions(scala_plugin PRIVATE
+    QT_PLUGIN
+)
+
+# ── RPATH ─────────────────────────────────────────────────────────────────────
+if(APPLE)
+    set_target_properties(scala_plugin PROPERTIES
+        BUILD_RPATH   "@loader_path"
+        INSTALL_RPATH "@loader_path"
+    )
+elseif(UNIX)
+    set_target_properties(scala_plugin PROPERTIES
+        BUILD_RPATH   "$ORIGIN"
+        INSTALL_RPATH "$ORIGIN"
+    )
+endif()
+
+# ── Install ───────────────────────────────────────────────────────────────────
+install(TARGETS scala_plugin
+    LIBRARY DESTINATION lib/scala
+)
+
+install(FILES ${CMAKE_SOURCE_DIR}/metadata.json
+    DESTINATION lib/scala
+    RENAME manifest.json
+)
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+option(BUILD_TESTS "Build unit tests" OFF)
+if(BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+BUILD_DIR ?= build
+CMAKE_FLAGS ?= -DCMAKE_BUILD_TYPE=Debug
+
+.PHONY: all clean build test
+
+all: build
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+build: $(BUILD_DIR)
+	cd $(BUILD_DIR) && cmake .. $(CMAKE_FLAGS) && make -j$$(nproc)
+
+test: $(BUILD_DIR)
+	cd $(BUILD_DIR) && cmake .. $(CMAKE_FLAGS) -DBUILD_TESTS=ON && make -j$$(nproc) && ctest --output-on-failure
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,14 @@
+{
+  description = "Secure Calendar App — privacy-first shared calendar module for Logos Core";
+
+  inputs = {
+    logos-module-builder.url = "github:logos-co/logos-module-builder";
+    nixpkgs.follows = "logos-module-builder/nixpkgs";
+  };
+
+  outputs = { self, logos-module-builder, nixpkgs, ... }:
+    logos-module-builder.lib.mkLogosModule {
+      src = ./.;
+      configFile = ./module.yaml;
+    };
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,19 @@
+{
+  "name": "scala",
+  "version": "0.1.0",
+  "description": "Secure Calendar App — privacy-first shared calendar module for Logos Core",
+  "author": "Jimmy Claw",
+  "type": "core",
+  "category": "general",
+  "main": {
+    "linux-x86_64": "scala_plugin.so",
+    "linux-amd64": "scala_plugin.so",
+    "linux-arm64": "scala_plugin.so",
+    "linux-aarch64": "scala_plugin.so",
+    "darwin-x86_64": "scala_plugin.dylib",
+    "darwin-arm64": "scala_plugin.dylib",
+    "windows-x86_64": "scala_plugin.dll"
+  },
+  "dependencies": ["kv_module"],
+  "capabilities": []
+}

--- a/module.yaml
+++ b/module.yaml
@@ -1,0 +1,19 @@
+name: scala
+version: 0.1.0
+type: core
+category: general
+description: "Secure Calendar App — privacy-first shared calendar module for Logos Core"
+
+dependencies:
+  - kv_module
+
+nix_packages:
+  build: []
+  runtime: []
+
+external_libraries: []
+
+cmake:
+  find_packages: []
+  extra_sources: []
+  proto_files: []

--- a/qml/CalendarView.qml
+++ b/qml/CalendarView.qml
@@ -1,0 +1,140 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Item {
+    id: root
+    width: 800
+    height: 600
+
+    RowLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        // ── Calendar list sidebar ────────────────────────────────────────────
+        Rectangle {
+            Layout.preferredWidth: 200
+            Layout.fillHeight: true
+            color: "#f5f5f5"
+            border.color: "#ddd"
+
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: 12
+                spacing: 8
+
+                Text {
+                    text: "Calendars"
+                    font.pixelSize: 18
+                    font.bold: true
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    color: "transparent"
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: "No calendars yet"
+                        color: "#999"
+                        font.pixelSize: 13
+                    }
+                }
+            }
+        }
+
+        // ── Main calendar area ───────────────────────────────────────────────
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: 0
+
+            // Header
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 56
+                color: "#2196F3"
+
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: 16
+                    anchors.rightMargin: 16
+
+                    Text {
+                        text: "Scala Calendar"
+                        color: "white"
+                        font.pixelSize: 20
+                        font.bold: true
+                    }
+
+                    Item { Layout.fillWidth: true }
+
+                    Button {
+                        text: "Add Event"
+                        onClicked: {
+                            // No-op placeholder
+                            console.log("Add Event clicked (not yet implemented)")
+                        }
+                    }
+                }
+            }
+
+            // Month grid
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                color: "white"
+
+                GridLayout {
+                    anchors.fill: parent
+                    anchors.margins: 8
+                    columns: 7
+                    rowSpacing: 1
+                    columnSpacing: 1
+
+                    // Day-of-week headers
+                    Repeater {
+                        model: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+                        delegate: Rectangle {
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: 32
+                            color: "#e3f2fd"
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: modelData
+                                font.bold: true
+                                font.pixelSize: 12
+                                color: "#1565C0"
+                            }
+                        }
+                    }
+
+                    // Static 5x7 day cells (placeholder)
+                    Repeater {
+                        model: 35
+                        delegate: Rectangle {
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            border.color: "#eee"
+                            color: "white"
+
+                            Text {
+                                anchors.top: parent.top
+                                anchors.left: parent.left
+                                anchors.margins: 4
+                                text: {
+                                    var day = index - 5 + 1  // offset for month start
+                                    return (day >= 1 && day <= 31) ? day.toString() : ""
+                                }
+                                font.pixelSize: 11
+                                color: "#333"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/calendar_module.cpp
+++ b/src/calendar_module.cpp
@@ -1,0 +1,132 @@
+#include "calendar_module.h"
+
+#ifdef LOGOS_CORE_AVAILABLE
+#include <logos_api_provider.h>
+#include <logos_api_client.h>
+#endif
+
+#include <QDebug>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QUuid>
+
+// ── Construction ─────────────────────────────────────────────────────────────
+
+LogosCalendar::LogosCalendar(QObject *parent)
+    : QObject(parent) {}
+
+// ── Logos Core lifecycle ─────────────────────────────────────────────────────
+
+#ifdef LOGOS_CORE_AVAILABLE
+void LogosCalendar::initLogos(LogosAPI *logosAPIInstance) {
+    m_logosAPI = logosAPIInstance;
+
+    if (!m_logosAPI) {
+        qWarning() << "LogosCalendar: initLogos called with null LogosAPI";
+        qInfo() << "LogosCalendar: initialized (headless). version:" << version();
+        return;
+    }
+
+    // NOTE: Do NOT call logosAPI->getProvider()->registerObject() here.
+    // The SDK wraps us in a ModuleProxy that handles registration automatically.
+
+    m_kvClient = m_logosAPI->getClient("kv_module");
+    if (!m_kvClient) {
+        qWarning() << "LogosCalendar: failed to get kv_module client";
+    } else {
+        m_store.setClient(m_kvClient);
+    }
+
+    qInfo() << "LogosCalendar: initialized. version:" << version();
+    emit eventResponse("initialized", QVariantList() << "scala" << "0.1.0");
+}
+#endif
+
+// ── Calendar operations ──────────────────────────────────────────────────────
+
+QString LogosCalendar::createCalendar(const QString &name, const QString &color) {
+    scala::Calendar cal;
+    cal.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    cal.name = name;
+    cal.color = color;
+    cal.isShared = false;
+    qint64 now = QDateTime::currentMSecsSinceEpoch();
+    cal.createdAt = now;
+    cal.updatedAt = now;
+
+    m_store.saveCalendar(cal);
+
+    emit eventResponse("calendar_created", QVariantList() << cal.id << name);
+    return cal.id;
+}
+
+QString LogosCalendar::listCalendars() {
+    auto calendars = m_store.listCalendars();
+    QJsonArray arr;
+    for (const auto &cal : calendars)
+        arr.append(cal.toJson());
+    return QString::fromUtf8(QJsonDocument(arr).toJson(QJsonDocument::Compact));
+}
+
+bool LogosCalendar::deleteCalendar(const QString &id) {
+    bool ok = m_store.deleteCalendar(id);
+    if (ok)
+        emit eventResponse("calendar_deleted", QVariantList() << id);
+    return ok;
+}
+
+// ── Event operations ─────────────────────────────────────────────────────────
+
+QString LogosCalendar::createEvent(const QString &calendarId, const QString &eventJson) {
+    QJsonDocument doc = QJsonDocument::fromJson(eventJson.toUtf8());
+    QJsonObject obj = doc.object();
+
+    scala::CalendarEvent ev = scala::CalendarEvent::fromJson(obj);
+    ev.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    ev.calendarId = calendarId;
+    qint64 now = QDateTime::currentMSecsSinceEpoch();
+    ev.createdAt = now;
+    ev.updatedAt = now;
+
+    m_store.saveEvent(ev);
+
+    emit eventResponse("event_created", QVariantList() << ev.id << calendarId);
+    return ev.id;
+}
+
+bool LogosCalendar::updateEvent(const QString &eventJson) {
+    QJsonDocument doc = QJsonDocument::fromJson(eventJson.toUtf8());
+    QJsonObject obj = doc.object();
+
+    scala::CalendarEvent ev = scala::CalendarEvent::fromJson(obj);
+    ev.updatedAt = QDateTime::currentMSecsSinceEpoch();
+
+    bool ok = m_store.updateEvent(ev);
+    if (ok)
+        emit eventResponse("event_updated", QVariantList() << ev.id);
+    return ok;
+}
+
+bool LogosCalendar::deleteEvent(const QString &id) {
+    bool ok = m_store.deleteEvent(id);
+    if (ok)
+        emit eventResponse("event_deleted", QVariantList() << id);
+    return ok;
+}
+
+QString LogosCalendar::listEvents(const QString &calendarId) {
+    auto events = m_store.listEvents(calendarId);
+    QJsonArray arr;
+    for (const auto &ev : events)
+        arr.append(ev.toJson());
+    return QString::fromUtf8(QJsonDocument(arr).toJson(QJsonDocument::Compact));
+}
+
+QString LogosCalendar::getEvent(const QString &id) {
+    auto ev = m_store.getEvent(id);
+    if (ev.id.isEmpty())
+        return {};
+    return QString::fromUtf8(
+        QJsonDocument(ev.toJson()).toJson(QJsonDocument::Compact));
+}

--- a/src/calendar_module.h
+++ b/src/calendar_module.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "calendar_store.h"
+#include "types.h"
+
+#include <QObject>
+#include <QString>
+
+#ifdef LOGOS_CORE_AVAILABLE
+#include <interface.h>
+class LogosAPIClient;
+#endif
+
+/**
+ * ILogosCalendar — Public interface for the Scala calendar module.
+ */
+class ILogosCalendar {
+public:
+    virtual ~ILogosCalendar() = default;
+
+    virtual QString createCalendar(const QString &name, const QString &color) = 0;
+    virtual QString listCalendars() = 0;
+    virtual bool deleteCalendar(const QString &id) = 0;
+    virtual QString createEvent(const QString &calendarId, const QString &eventJson) = 0;
+    virtual bool updateEvent(const QString &eventJson) = 0;
+    virtual bool deleteEvent(const QString &id) = 0;
+    virtual QString listEvents(const QString &calendarId) = 0;
+    virtual QString getEvent(const QString &id) = 0;
+};
+
+#define ILogosCalendar_iid "com.logos.module.ILogosCalendar"
+Q_DECLARE_INTERFACE(ILogosCalendar, ILogosCalendar_iid)
+
+/**
+ * LogosCalendar — Qt plugin implementing the Scala calendar module.
+ */
+#ifdef LOGOS_CORE_AVAILABLE
+class LogosCalendar final : public QObject, public PluginInterface, public ILogosCalendar {
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID ILogosCalendar_iid FILE "metadata.json")
+    Q_INTERFACES(PluginInterface ILogosCalendar)
+#else
+class LogosCalendar final : public QObject, public ILogosCalendar {
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID ILogosCalendar_iid FILE "metadata.json")
+    Q_INTERFACES(ILogosCalendar)
+#endif
+
+public:
+    explicit LogosCalendar(QObject *parent = nullptr);
+    ~LogosCalendar() override = default;
+
+    // ── PluginInterface ─────────────────────────────────────────────────────
+#ifdef LOGOS_CORE_AVAILABLE
+    [[nodiscard]] QString name() const override { return QStringLiteral("scala"); }
+    Q_INVOKABLE QString version() const override { return QStringLiteral("0.1.0"); }
+    Q_INVOKABLE void initLogos(LogosAPI *logosAPIInstance);
+#else
+    [[nodiscard]] QString name() const { return QStringLiteral("scala"); }
+    Q_INVOKABLE QString version() const { return QStringLiteral("0.1.0"); }
+#endif
+
+    // ── ILogosCalendar ──────────────────────────────────────────────────────
+    Q_INVOKABLE QString createCalendar(const QString &name, const QString &color) override;
+    Q_INVOKABLE QString listCalendars() override;
+    Q_INVOKABLE bool deleteCalendar(const QString &id) override;
+    Q_INVOKABLE QString createEvent(const QString &calendarId, const QString &eventJson) override;
+    Q_INVOKABLE bool updateEvent(const QString &eventJson) override;
+    Q_INVOKABLE bool deleteEvent(const QString &id) override;
+    Q_INVOKABLE QString listEvents(const QString &calendarId) override;
+    Q_INVOKABLE QString getEvent(const QString &id) override;
+
+signals:
+    void eventResponse(const QString &eventName, const QVariantList &args);
+
+private:
+    CalendarStore m_store;
+
+#ifdef LOGOS_CORE_AVAILABLE
+    LogosAPI *m_logosAPI = nullptr;
+    LogosAPIClient *m_kvClient = nullptr;
+#endif
+};

--- a/src/calendar_store.cpp
+++ b/src/calendar_store.cpp
@@ -1,0 +1,217 @@
+#include "calendar_store.h"
+
+#ifdef LOGOS_CORE_AVAILABLE
+#include <logos_api_client.h>
+#endif
+
+#include <QDebug>
+#include <QJsonDocument>
+
+// ── Construction ─────────────────────────────────────────────────────────────
+
+CalendarStore::CalendarStore() = default;
+
+#ifdef LOGOS_CORE_AVAILABLE
+void CalendarStore::setClient(LogosAPIClient *client) {
+    m_kvClient = client;
+}
+#endif
+
+// ── KV helpers ───────────────────────────────────────────────────────────────
+
+void CalendarStore::kvSet(const QString &key, const QString &value) const {
+#ifdef LOGOS_CORE_AVAILABLE
+    if (m_kvClient) {
+        m_kvClient->invokeRemoteMethod("kv_module", "set",
+                                       QString(KV_NS), key, value);
+    }
+#else
+    m_mem[key] = value;
+#endif
+}
+
+QString CalendarStore::kvGet(const QString &key) const {
+#ifdef LOGOS_CORE_AVAILABLE
+    if (m_kvClient) {
+        QVariant result = m_kvClient->invokeRemoteMethod("kv_module", "get",
+                                                         QString(KV_NS), key);
+        return result.toString();
+    }
+    return {};
+#else
+    return m_mem.value(key);
+#endif
+}
+
+void CalendarStore::kvRemove(const QString &key) const {
+#ifdef LOGOS_CORE_AVAILABLE
+    if (m_kvClient) {
+        m_kvClient->invokeRemoteMethod("kv_module", "remove",
+                                       QString(KV_NS), key);
+    }
+#else
+    m_mem.remove(key);
+#endif
+}
+
+// ── Index helpers ────────────────────────────────────────────────────────────
+
+QStringList CalendarStore::getIndex(const QString &indexKey) const {
+    QString raw = kvGet(indexKey);
+    if (raw.isEmpty())
+        return {};
+
+    QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8());
+    QStringList ids;
+    for (const auto &v : doc.array())
+        ids.append(v.toString());
+    return ids;
+}
+
+void CalendarStore::setIndex(const QString &indexKey, const QStringList &ids) const {
+    QJsonArray arr;
+    for (const auto &id : ids)
+        arr.append(id);
+    kvSet(indexKey, QString::fromUtf8(QJsonDocument(arr).toJson(QJsonDocument::Compact)));
+}
+
+void CalendarStore::addToIndex(const QString &indexKey, const QString &id) const {
+    QStringList ids = getIndex(indexKey);
+    if (!ids.contains(id)) {
+        ids.append(id);
+        setIndex(indexKey, ids);
+    }
+}
+
+void CalendarStore::removeFromIndex(const QString &indexKey, const QString &id) const {
+    QStringList ids = getIndex(indexKey);
+    ids.removeAll(id);
+    setIndex(indexKey, ids);
+}
+
+// ── Calendar CRUD ────────────────────────────────────────────────────────────
+
+QString CalendarStore::saveCalendar(const scala::Calendar &cal) {
+    QString key = QStringLiteral("calendar:") + cal.id;
+    QString json = QString::fromUtf8(
+        QJsonDocument(cal.toJson()).toJson(QJsonDocument::Compact));
+    kvSet(key, json);
+    addToIndex(QStringLiteral("calendars"), cal.id);
+    return cal.id;
+}
+
+scala::Calendar CalendarStore::getCalendar(const QString &id) const {
+    QString key = QStringLiteral("calendar:") + id;
+    QString raw = kvGet(key);
+    if (raw.isEmpty())
+        return {};
+
+    QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8());
+    return scala::Calendar::fromJson(doc.object());
+}
+
+QList<scala::Calendar> CalendarStore::listCalendars() const {
+    QStringList ids = getIndex(QStringLiteral("calendars"));
+    QList<scala::Calendar> result;
+    for (const auto &id : ids) {
+        auto cal = getCalendar(id);
+        if (!cal.id.isEmpty())
+            result.append(cal);
+    }
+    return result;
+}
+
+bool CalendarStore::deleteCalendar(const QString &id) {
+    QString key = QStringLiteral("calendar:") + id;
+    QString raw = kvGet(key);
+    if (raw.isEmpty())
+        return false;
+
+    // Delete all events in this calendar
+    QStringList eventIds = getIndex(QStringLiteral("events:") + id);
+    for (const auto &eid : eventIds)
+        kvRemove(QStringLiteral("event:") + id + QStringLiteral(":") + eid);
+    kvRemove(QStringLiteral("events:") + id);
+
+    kvRemove(key);
+    removeFromIndex(QStringLiteral("calendars"), id);
+    return true;
+}
+
+// ── Event CRUD ───────────────────────────────────────────────────────────────
+
+QString CalendarStore::saveEvent(const scala::CalendarEvent &ev) {
+    QString key = QStringLiteral("event:") + ev.calendarId +
+                  QStringLiteral(":") + ev.id;
+    QString json = QString::fromUtf8(
+        QJsonDocument(ev.toJson()).toJson(QJsonDocument::Compact));
+    kvSet(key, json);
+    addToIndex(QStringLiteral("events:") + ev.calendarId, ev.id);
+    return ev.id;
+}
+
+scala::CalendarEvent CalendarStore::getEvent(const QString &id) const {
+    // We need to find which calendar this event belongs to
+    QString calendarId = findCalendarIdForEvent(id);
+    if (calendarId.isEmpty())
+        return {};
+
+    QString key = QStringLiteral("event:") + calendarId +
+                  QStringLiteral(":") + id;
+    QString raw = kvGet(key);
+    if (raw.isEmpty())
+        return {};
+
+    QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8());
+    return scala::CalendarEvent::fromJson(doc.object());
+}
+
+QList<scala::CalendarEvent> CalendarStore::listEvents(const QString &calendarId) const {
+    QStringList ids = getIndex(QStringLiteral("events:") + calendarId);
+    QList<scala::CalendarEvent> result;
+    for (const auto &id : ids) {
+        QString key = QStringLiteral("event:") + calendarId +
+                      QStringLiteral(":") + id;
+        QString raw = kvGet(key);
+        if (raw.isEmpty())
+            continue;
+        QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8());
+        result.append(scala::CalendarEvent::fromJson(doc.object()));
+    }
+    return result;
+}
+
+bool CalendarStore::updateEvent(const scala::CalendarEvent &ev) {
+    QString key = QStringLiteral("event:") + ev.calendarId +
+                  QStringLiteral(":") + ev.id;
+    QString existing = kvGet(key);
+    if (existing.isEmpty())
+        return false;
+
+    QString json = QString::fromUtf8(
+        QJsonDocument(ev.toJson()).toJson(QJsonDocument::Compact));
+    kvSet(key, json);
+    return true;
+}
+
+bool CalendarStore::deleteEvent(const QString &id) {
+    QString calendarId = findCalendarIdForEvent(id);
+    if (calendarId.isEmpty())
+        return false;
+
+    QString key = QStringLiteral("event:") + calendarId +
+                  QStringLiteral(":") + id;
+    kvRemove(key);
+    removeFromIndex(QStringLiteral("events:") + calendarId, id);
+    return true;
+}
+
+QString CalendarStore::findCalendarIdForEvent(const QString &eventId) const {
+    QStringList calIds = getIndex(QStringLiteral("calendars"));
+    for (const auto &calId : calIds) {
+        QStringList eventIds = getIndex(QStringLiteral("events:") + calId);
+        if (eventIds.contains(eventId))
+            return calId;
+    }
+    return {};
+}

--- a/src/calendar_store.h
+++ b/src/calendar_store.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "types.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QString>
+#include <QStringList>
+
+#include <functional>
+
+#ifdef LOGOS_CORE_AVAILABLE
+class LogosAPIClient;
+#endif
+
+/**
+ * CalendarStore — wraps KV operations for calendar/event persistence.
+ *
+ * Under Logos Core, delegates to kv_module via inter-module QtRO calls.
+ * In standalone/test mode, uses an in-memory map fallback.
+ *
+ * Key patterns (namespace "scala"):
+ *   calendar:{id}          → Calendar JSON
+ *   event:{calendarId}:{id} → CalendarEvent JSON
+ *   calendars              → JSON array of calendar IDs
+ *   events:{calendarId}    → JSON array of event IDs
+ */
+class CalendarStore {
+public:
+    CalendarStore();
+
+#ifdef LOGOS_CORE_AVAILABLE
+    void setClient(LogosAPIClient *client);
+#endif
+
+    // ── Calendar CRUD ────────────────────────────────────────────────────────
+    QString saveCalendar(const scala::Calendar &cal);
+    scala::Calendar getCalendar(const QString &id) const;
+    QList<scala::Calendar> listCalendars() const;
+    bool deleteCalendar(const QString &id);
+
+    // ── Event CRUD ───────────────────────────────────────────────────────────
+    QString saveEvent(const scala::CalendarEvent &ev);
+    scala::CalendarEvent getEvent(const QString &id) const;
+    QList<scala::CalendarEvent> listEvents(const QString &calendarId) const;
+    bool updateEvent(const scala::CalendarEvent &ev);
+    bool deleteEvent(const QString &id);
+
+private:
+    static constexpr const char *KV_NS = "scala";
+
+    // KV helpers
+    void kvSet(const QString &key, const QString &value) const;
+    QString kvGet(const QString &key) const;
+    void kvRemove(const QString &key) const;
+
+    // Index helpers
+    QStringList getIndex(const QString &indexKey) const;
+    void setIndex(const QString &indexKey, const QStringList &ids) const;
+    void addToIndex(const QString &indexKey, const QString &id) const;
+    void removeFromIndex(const QString &indexKey, const QString &id) const;
+
+    // Find which calendar owns an event (scans index keys)
+    QString findCalendarIdForEvent(const QString &eventId) const;
+
+#ifdef LOGOS_CORE_AVAILABLE
+    LogosAPIClient *m_kvClient = nullptr;
+#else
+    // In-memory fallback for standalone builds
+    mutable QMap<QString, QString> m_mem;
+#endif
+};

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -1,0 +1,5 @@
+/**
+ * plugin.cpp — Qt plugin entry point for LogosCalendar.
+ */
+
+#include "calendar_module.h"

--- a/src/types.h
+++ b/src/types.h
@@ -1,0 +1,100 @@
+#ifndef SCALA_TYPES_H
+#define SCALA_TYPES_H
+
+#include <QDateTime>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QString>
+#include <QStringList>
+#include <QUuid>
+
+namespace scala {
+
+struct CalendarEvent {
+    QString id;
+    QString calendarId;
+    QString title;
+    QDateTime startTime;
+    QDateTime endTime;
+    bool allDay = false;
+    QString description;
+    QString location;
+    QStringList attendees;
+    qint64 createdAt = 0;
+    qint64 updatedAt = 0;
+
+    QJsonObject toJson() const {
+        QJsonObject obj;
+        obj["id"] = id;
+        obj["calendarId"] = calendarId;
+        obj["title"] = title;
+        obj["startTime"] = startTime.toMSecsSinceEpoch();
+        obj["endTime"] = endTime.toMSecsSinceEpoch();
+        obj["allDay"] = allDay;
+        obj["description"] = description;
+        obj["location"] = location;
+        QJsonArray att;
+        for (const auto &a : attendees)
+            att.append(a);
+        obj["attendees"] = att;
+        obj["createdAt"] = createdAt;
+        obj["updatedAt"] = updatedAt;
+        return obj;
+    }
+
+    static CalendarEvent fromJson(const QJsonObject &obj) {
+        CalendarEvent ev;
+        ev.id = obj["id"].toString();
+        ev.calendarId = obj["calendarId"].toString();
+        ev.title = obj["title"].toString();
+        ev.startTime = QDateTime::fromMSecsSinceEpoch(obj["startTime"].toDouble());
+        ev.endTime = QDateTime::fromMSecsSinceEpoch(obj["endTime"].toDouble());
+        ev.allDay = obj["allDay"].toBool();
+        ev.description = obj["description"].toString();
+        ev.location = obj["location"].toString();
+        QJsonArray att = obj["attendees"].toArray();
+        for (const auto &a : att)
+            ev.attendees.append(a.toString());
+        ev.createdAt = static_cast<qint64>(obj["createdAt"].toDouble());
+        ev.updatedAt = static_cast<qint64>(obj["updatedAt"].toDouble());
+        return ev;
+    }
+};
+
+struct Calendar {
+    QString id;
+    QString name;
+    QString color;
+    bool isShared = false;
+    QString encryptionKey;
+    qint64 createdAt = 0;
+    qint64 updatedAt = 0;
+
+    QJsonObject toJson() const {
+        QJsonObject obj;
+        obj["id"] = id;
+        obj["name"] = name;
+        obj["color"] = color;
+        obj["isShared"] = isShared;
+        obj["encryptionKey"] = encryptionKey;
+        obj["createdAt"] = createdAt;
+        obj["updatedAt"] = updatedAt;
+        return obj;
+    }
+
+    static Calendar fromJson(const QJsonObject &obj) {
+        Calendar cal;
+        cal.id = obj["id"].toString();
+        cal.name = obj["name"].toString();
+        cal.color = obj["color"].toString();
+        cal.isShared = obj["isShared"].toBool();
+        cal.encryptionKey = obj["encryptionKey"].toString();
+        cal.createdAt = static_cast<qint64>(obj["createdAt"].toDouble());
+        cal.updatedAt = static_cast<qint64>(obj["updatedAt"].toDouble());
+        return cal;
+    }
+};
+
+} // namespace scala
+
+#endif // SCALA_TYPES_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.16)
+
+if(NOT CMAKE_PROJECT_NAME OR CMAKE_PROJECT_NAME STREQUAL "scala_tests")
+    project(scala_tests LANGUAGES CXX)
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+find_package(Qt6 REQUIRED COMPONENTS Core Test)
+
+set(CMAKE_AUTOMOC ON)
+
+enable_testing()
+
+add_executable(test_calendar
+    test_calendar.cpp
+)
+
+target_include_directories(test_calendar PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+)
+
+target_link_libraries(test_calendar PRIVATE
+    Qt6::Core
+    Qt6::Test
+)
+
+add_test(NAME test_calendar COMMAND test_calendar)

--- a/tests/test_calendar.cpp
+++ b/tests/test_calendar.cpp
@@ -1,0 +1,143 @@
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTest>
+
+#include "types.h"
+
+class TestCalendar : public QObject {
+    Q_OBJECT
+
+private slots:
+    void calendarJsonRoundtrip();
+    void calendarJsonRoundtripShared();
+    void eventJsonRoundtrip();
+    void eventJsonRoundtripAllDay();
+    void eventJsonRoundtripWithAttendees();
+    void fromJsonMissingFields();
+};
+
+void TestCalendar::calendarJsonRoundtrip() {
+    scala::Calendar cal;
+    cal.id = "cal-001";
+    cal.name = "Work";
+    cal.color = "#FF5722";
+    cal.isShared = false;
+    cal.encryptionKey = "";
+    cal.createdAt = 1700000000000LL;
+    cal.updatedAt = 1700000001000LL;
+
+    QJsonObject json = cal.toJson();
+    scala::Calendar restored = scala::Calendar::fromJson(json);
+
+    QCOMPARE(restored.id, cal.id);
+    QCOMPARE(restored.name, cal.name);
+    QCOMPARE(restored.color, cal.color);
+    QCOMPARE(restored.isShared, cal.isShared);
+    QCOMPARE(restored.encryptionKey, cal.encryptionKey);
+    QCOMPARE(restored.createdAt, cal.createdAt);
+    QCOMPARE(restored.updatedAt, cal.updatedAt);
+}
+
+void TestCalendar::calendarJsonRoundtripShared() {
+    scala::Calendar cal;
+    cal.id = "cal-shared-001";
+    cal.name = "Team Sprint";
+    cal.color = "#4CAF50";
+    cal.isShared = true;
+    cal.encryptionKey = "dGVzdGtleQ==";
+    cal.createdAt = 1700000000000LL;
+    cal.updatedAt = 1700000001000LL;
+
+    QJsonObject json = cal.toJson();
+    scala::Calendar restored = scala::Calendar::fromJson(json);
+
+    QCOMPARE(restored.isShared, true);
+    QCOMPARE(restored.encryptionKey, cal.encryptionKey);
+}
+
+void TestCalendar::eventJsonRoundtrip() {
+    scala::CalendarEvent ev;
+    ev.id = "evt-001";
+    ev.calendarId = "cal-001";
+    ev.title = "Standup";
+    ev.startTime = QDateTime::fromMSecsSinceEpoch(1700000000000LL);
+    ev.endTime = QDateTime::fromMSecsSinceEpoch(1700000900000LL);
+    ev.allDay = false;
+    ev.description = "Daily standup meeting";
+    ev.location = "Room 42";
+    ev.attendees = {};
+    ev.createdAt = 1700000000000LL;
+    ev.updatedAt = 1700000000000LL;
+
+    QJsonObject json = ev.toJson();
+    scala::CalendarEvent restored = scala::CalendarEvent::fromJson(json);
+
+    QCOMPARE(restored.id, ev.id);
+    QCOMPARE(restored.calendarId, ev.calendarId);
+    QCOMPARE(restored.title, ev.title);
+    QCOMPARE(restored.startTime, ev.startTime);
+    QCOMPARE(restored.endTime, ev.endTime);
+    QCOMPARE(restored.allDay, ev.allDay);
+    QCOMPARE(restored.description, ev.description);
+    QCOMPARE(restored.location, ev.location);
+    QCOMPARE(restored.createdAt, ev.createdAt);
+    QCOMPARE(restored.updatedAt, ev.updatedAt);
+}
+
+void TestCalendar::eventJsonRoundtripAllDay() {
+    scala::CalendarEvent ev;
+    ev.id = "evt-allday";
+    ev.calendarId = "cal-001";
+    ev.title = "Holiday";
+    ev.startTime = QDateTime::fromMSecsSinceEpoch(1700000000000LL);
+    ev.endTime = QDateTime::fromMSecsSinceEpoch(1700086400000LL);
+    ev.allDay = true;
+    ev.createdAt = 1700000000000LL;
+    ev.updatedAt = 1700000000000LL;
+
+    QJsonObject json = ev.toJson();
+    scala::CalendarEvent restored = scala::CalendarEvent::fromJson(json);
+
+    QCOMPARE(restored.allDay, true);
+    QCOMPARE(restored.title, QStringLiteral("Holiday"));
+}
+
+void TestCalendar::eventJsonRoundtripWithAttendees() {
+    scala::CalendarEvent ev;
+    ev.id = "evt-attend";
+    ev.calendarId = "cal-001";
+    ev.title = "Planning";
+    ev.startTime = QDateTime::fromMSecsSinceEpoch(1700000000000LL);
+    ev.endTime = QDateTime::fromMSecsSinceEpoch(1700003600000LL);
+    ev.attendees = {"pubkey_alice", "pubkey_bob", "pubkey_carol"};
+    ev.createdAt = 1700000000000LL;
+    ev.updatedAt = 1700000000000LL;
+
+    QJsonObject json = ev.toJson();
+    scala::CalendarEvent restored = scala::CalendarEvent::fromJson(json);
+
+    QCOMPARE(restored.attendees.size(), 3);
+    QCOMPARE(restored.attendees.at(0), QStringLiteral("pubkey_alice"));
+    QCOMPARE(restored.attendees.at(1), QStringLiteral("pubkey_bob"));
+    QCOMPARE(restored.attendees.at(2), QStringLiteral("pubkey_carol"));
+}
+
+void TestCalendar::fromJsonMissingFields() {
+    // Empty JSON should produce default-initialized structs
+    QJsonObject emptyObj;
+
+    scala::Calendar cal = scala::Calendar::fromJson(emptyObj);
+    QVERIFY(cal.id.isEmpty());
+    QVERIFY(cal.name.isEmpty());
+    QCOMPARE(cal.isShared, false);
+    QCOMPARE(cal.createdAt, 0LL);
+
+    scala::CalendarEvent ev = scala::CalendarEvent::fromJson(emptyObj);
+    QVERIFY(ev.id.isEmpty());
+    QVERIFY(ev.title.isEmpty());
+    QCOMPARE(ev.allDay, false);
+    QCOMPARE(ev.attendees.size(), 0);
+}
+
+QTEST_MAIN(TestCalendar)
+#include "test_calendar.moc"


### PR DESCRIPTION
## Summary

- **LogosCalendar** C++ Qt plugin implementing `ILogosCalendar` interface with calendar/event CRUD operations
- **CalendarEvent + Calendar** data model with full JSON serialization/deserialization (`types.h`)
- **CalendarStore** wrapping `kv_module` inter-module QtRO calls with key patterns: `calendar:{id}`, `event:{calId}:{id}`, index keys `calendars` and `events:{calId}`
- Placeholder **CalendarView.qml** with month grid, header bar, sidebar
- **Unit tests** for data model JSON roundtrip (6 test cases, all passing)
- Build config: CMakeLists.txt, Makefile, metadata.json, module.yaml, flake.nix

Implements issues #1, #2, #4.

## Test plan

- [x] `cmake .. -DCMAKE_BUILD_TYPE=Debug && make -j4` — plugin builds clean
- [x] `cmake .. -DBUILD_TESTS=ON && make -j4 && ctest` — all 6 data model tests pass
- [ ] Integration test with logos-kv-module (future, requires logoscore runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)