### PR TITLE
feat: QML UI — calendar grid, sidebar, event modal, event details

### DIFF
--- a/qml/CalendarGrid.qml
+++ b/qml/CalendarGrid.qml
@@ -1,0 +1,232 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Item {
+    id: root
+
+    // ── Theme colors ───────────────────────────────────────────────────────
+    property color bgColor: "#ffffff"
+    property color headerBg: "#e3f2fd"
+    property color headerText: "#1565C0"
+    property color cellBorder: "#e0e0e0"
+    property color todayBg: "#e8f5e9"
+    property color todayText: "#2e7d32"
+    property color selectedBg: "#e3f2fd"
+    property color dayTextColor: "#333333"
+    property color otherMonthText: "#bdbdbd"
+    property color hoverBg: "#f5f5f5"
+
+    // ── State ──────────────────────────────────────────────────────────────
+    property int displayYear: new Date().getFullYear()
+    property int displayMonth: new Date().getMonth()
+    property int selectedDay: -1
+    property var events: []       // list of {day: int, color: string}
+
+    signal dayClicked(int day, int month, int year)
+    signal navigated(int month, int year)
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+    function daysInMonth(month, year) {
+        return new Date(year, month + 1, 0).getDate();
+    }
+    function firstDayOfWeek(month, year) {
+        return new Date(year, month, 1).getDay();
+    }
+    function monthName(month) {
+        var names = ["January","February","March","April","May","June",
+                     "July","August","September","October","November","December"];
+        return names[month];
+    }
+    function isToday(day) {
+        var now = new Date();
+        return day === now.getDate()
+            && displayMonth === now.getMonth()
+            && displayYear === now.getFullYear();
+    }
+    function eventsForDay(day) {
+        var result = [];
+        for (var i = 0; i < events.length; i++) {
+            if (events[i].day === day) result.push(events[i]);
+        }
+        return result;
+    }
+
+    function goToPrevMonth() {
+        if (displayMonth === 0) {
+            displayMonth = 11;
+            displayYear--;
+        } else {
+            displayMonth--;
+        }
+        selectedDay = -1;
+        navigated(displayMonth, displayYear);
+    }
+    function goToNextMonth() {
+        if (displayMonth === 11) {
+            displayMonth = 0;
+            displayYear++;
+        } else {
+            displayMonth++;
+        }
+        selectedDay = -1;
+        navigated(displayMonth, displayYear);
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        // ── Month navigation toolbar ───────────────────────────────────────
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 44
+            color: bgColor
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 8
+                anchors.rightMargin: 8
+
+                Button {
+                    text: "<"
+                    flat: true
+                    onClicked: goToPrevMonth()
+                    implicitWidth: 36
+                    implicitHeight: 36
+                }
+
+                Item { Layout.fillWidth: true }
+
+                Text {
+                    text: monthName(displayMonth) + " " + displayYear
+                    font.pixelSize: 16
+                    font.bold: true
+                    color: dayTextColor
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: ">"
+                    flat: true
+                    onClicked: goToNextMonth()
+                    implicitWidth: 36
+                    implicitHeight: 36
+                }
+            }
+        }
+
+        // ── Day-of-week headers ────────────────────────────────────────────
+        Row {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 28
+
+            Repeater {
+                model: ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"]
+                delegate: Rectangle {
+                    width: root.width / 7
+                    height: 28
+                    color: headerBg
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: modelData
+                        font.pixelSize: 11
+                        font.bold: true
+                        color: headerText
+                    }
+                }
+            }
+        }
+
+        // ── Day cells grid (6 rows x 7 cols = 42 cells) ───────────────────
+        Grid {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            columns: 7
+
+            Repeater {
+                model: 42
+                delegate: Rectangle {
+                    id: dayCell
+                    width: root.width / 7
+                    height: (root.height - 44 - 28) / 6
+                    border.color: cellBorder
+                    border.width: 1
+
+                    property int dayNumber: {
+                        var offset = firstDayOfWeek(displayMonth, displayYear);
+                        var d = index - offset + 1;
+                        return d;
+                    }
+                    property bool isCurrentMonth: dayNumber >= 1
+                        && dayNumber <= daysInMonth(displayMonth, displayYear)
+                    property bool isTodayCell: isCurrentMonth && isToday(dayNumber)
+                    property bool isSelected: isCurrentMonth
+                        && dayNumber === selectedDay
+
+                    color: {
+                        if (!isCurrentMonth) return bgColor;
+                        if (isSelected) return selectedBg;
+                        if (isTodayCell) return todayBg;
+                        if (cellMouse.containsMouse) return hoverBg;
+                        return bgColor;
+                    }
+
+                    MouseArea {
+                        id: cellMouse
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        onClicked: {
+                            if (dayCell.isCurrentMonth) {
+                                selectedDay = dayCell.dayNumber;
+                                dayClicked(dayCell.dayNumber,
+                                           displayMonth, displayYear);
+                            }
+                        }
+                    }
+
+                    ColumnLayout {
+                        anchors.fill: parent
+                        anchors.margins: 2
+                        spacing: 1
+
+                        Text {
+                            text: dayCell.isCurrentMonth
+                                  ? dayCell.dayNumber.toString() : ""
+                            font.pixelSize: 12
+                            font.bold: dayCell.isTodayCell
+                            color: {
+                                if (dayCell.isTodayCell) return todayText;
+                                if (!dayCell.isCurrentMonth)
+                                    return otherMonthText;
+                                return dayTextColor;
+                            }
+                        }
+
+                        // Event indicators (colored dots)
+                        Row {
+                            spacing: 3
+                            visible: dayCell.isCurrentMonth
+
+                            Repeater {
+                                model: dayCell.isCurrentMonth
+                                       ? eventsForDay(dayCell.dayNumber) : []
+                                delegate: Rectangle {
+                                    width: 6
+                                    height: 6
+                                    radius: 3
+                                    color: modelData.color || "#2196F3"
+                                }
+                            }
+                        }
+
+                        Item { Layout.fillHeight: true }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qml/CalendarSidebar.qml
+++ b/qml/CalendarSidebar.qml
@@ -1,0 +1,134 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Rectangle {
+    id: root
+    color: "#f9f9f9"
+    border.color: "#e0e0e0"
+    border.width: 1
+
+    // ── Theme ──────────────────────────────────────────────────────────────
+    property color titleColor: "#212121"
+    property color subtitleColor: "#757575"
+    property color accentColor: "#2196F3"
+    property color newBtnColor: "#4CAF50"
+
+    // ── Data ───────────────────────────────────────────────────────────────
+    property alias calendarModel: calendarList.model
+
+    signal calendarToggled(string calendarId, bool visible)
+    signal newCalendarRequested()
+    signal calendarSelected(string calendarId)
+
+    // ── Default calendars (mock) ───────────────────────────────────────────
+    ListModel {
+        id: defaultModel
+        ListElement { calId: "personal"; calName: "Personal";
+                      calColor: "#4CAF50"; calVisible: true }
+        ListElement { calId: "work";     calName: "Work";
+                      calColor: "#2196F3"; calVisible: true }
+        ListElement { calId: "family";   calName: "Family";
+                      calColor: "#FF9800"; calVisible: true }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 12
+        spacing: 12
+
+        // ── Header ─────────────────────────────────────────────────────────
+        Text {
+            text: "Calendars"
+            font.pixelSize: 18
+            font.bold: true
+            color: titleColor
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            height: 1
+            color: "#e0e0e0"
+        }
+
+        // ── Calendar list ──────────────────────────────────────────────────
+        ListView {
+            id: calendarList
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            model: defaultModel
+            spacing: 2
+            clip: true
+
+            delegate: Rectangle {
+                width: calendarList.width
+                height: 40
+                radius: 6
+                color: delegateMouse.containsMouse ? "#f0f0f0" : "transparent"
+
+                MouseArea {
+                    id: delegateMouse
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onClicked: calendarSelected(calId)
+                }
+
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: 8
+                    anchors.rightMargin: 8
+                    spacing: 8
+
+                    // Color indicator
+                    Rectangle {
+                        width: 12
+                        height: 12
+                        radius: 6
+                        color: calColor
+                    }
+
+                    // Calendar name
+                    Text {
+                        text: calName
+                        font.pixelSize: 14
+                        color: titleColor
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
+                    }
+
+                    // Visibility toggle
+                    CheckBox {
+                        checked: calVisible
+                        onToggled: {
+                            calVisible = checked;
+                            calendarToggled(calId, checked);
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── New Calendar button ────────────────────────────────────────────
+        Button {
+            Layout.fillWidth: true
+            text: "+ New Calendar"
+            onClicked: newCalendarRequested()
+
+            background: Rectangle {
+                radius: 6
+                color: parent.pressed ? Qt.darker(newBtnColor, 1.2)
+                     : parent.hovered ? Qt.lighter(newBtnColor, 1.1)
+                     : newBtnColor
+            }
+
+            contentItem: Text {
+                text: parent.text
+                color: "white"
+                font.pixelSize: 14
+                font.bold: true
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+            }
+        }
+    }
+}

--- a/qml/CalendarView.qml
+++ b/qml/CalendarView.qml
@@ -7,54 +7,59 @@ Item {
     width: 800
     height: 600
 
+    // ── Theme colors ───────────────────────────────────────────────────────
+    property color primaryColor: "#2196F3"
+    property color bgColor: "#ffffff"
+    property color toolbarColor: "#2196F3"
+    property color sidebarBg: "#f9f9f9"
+    property color newEventBtnColor: "#4CAF50"
+
+    // ── State ──────────────────────────────────────────────────────────────
+    property var selectedEvent: null
+    property bool showEventDetails: false
+
+    // ── Mock events for demo ───────────────────────────────────────────────
+    property var mockEvents: [
+        { day: 5,  color: "#4CAF50" },
+        { day: 5,  color: "#2196F3" },
+        { day: 12, color: "#4CAF50" },
+        { day: 18, color: "#FF9800" },
+        { day: 22, color: "#2196F3" },
+        { day: 22, color: "#FF9800" },
+        { day: 28, color: "#4CAF50" }
+    ]
+
     RowLayout {
         anchors.fill: parent
         spacing: 0
 
-        // ── Calendar list sidebar ────────────────────────────────────────────
-        Rectangle {
-            Layout.preferredWidth: 200
+        // ── Sidebar ────────────────────────────────────────────────────────
+        CalendarSidebar {
+            Layout.preferredWidth: 220
             Layout.fillHeight: true
-            color: "#f5f5f5"
-            border.color: "#ddd"
 
-            ColumnLayout {
-                anchors.fill: parent
-                anchors.margins: 12
-                spacing: 8
-
-                Text {
-                    text: "Calendars"
-                    font.pixelSize: 18
-                    font.bold: true
-                }
-
-                Rectangle {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    color: "transparent"
-
-                    Text {
-                        anchors.centerIn: parent
-                        text: "No calendars yet"
-                        color: "#999"
-                        font.pixelSize: 13
-                    }
-                }
+            onCalendarToggled: function(calId, vis) {
+                console.log("Calendar toggled:", calId, vis);
+            }
+            onNewCalendarRequested: {
+                console.log("New calendar requested");
+            }
+            onCalendarSelected: function(calId) {
+                console.log("Calendar selected:", calId);
             }
         }
 
-        // ── Main calendar area ───────────────────────────────────────────────
+        // ── Main area ──────────────────────────────────────────────────────
         ColumnLayout {
             Layout.fillWidth: true
             Layout.fillHeight: true
             spacing: 0
 
-            // Header
+            // ── Toolbar ────────────────────────────────────────────────────
             Rectangle {
                 Layout.fillWidth: true
-                Layout.preferredHeight: 56
-                color: "#2196F3"
+                Layout.preferredHeight: 52
+                color: toolbarColor
 
                 RowLayout {
                     anchors.fill: parent
@@ -71,70 +76,123 @@ Item {
                     Item { Layout.fillWidth: true }
 
                     Button {
-                        text: "Add Event"
+                        text: "+ New Event"
                         onClicked: {
-                            // No-op placeholder
-                            console.log("Add Event clicked (not yet implemented)")
+                            eventModal.clear();
+                            eventModal.open();
+                        }
+                        background: Rectangle {
+                            radius: 6
+                            color: parent.pressed
+                                ? Qt.darker(newEventBtnColor, 1.2)
+                                : parent.hovered
+                                  ? Qt.lighter(newEventBtnColor, 1.1)
+                                  : newEventBtnColor
+                        }
+                        contentItem: Text {
+                            text: parent.text
+                            color: "white"
+                            font.pixelSize: 14
+                            font.bold: true
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
                         }
                     }
                 }
             }
 
-            // Month grid
-            Rectangle {
+            // ── Content: grid + optional details panel ─────────────────────
+            RowLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-                color: "white"
+                spacing: 0
 
-                GridLayout {
-                    anchors.fill: parent
-                    anchors.margins: 8
-                    columns: 7
-                    rowSpacing: 1
-                    columnSpacing: 1
+                // Calendar grid
+                CalendarGrid {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    events: mockEvents
 
-                    // Day-of-week headers
-                    Repeater {
-                        model: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
-                        delegate: Rectangle {
-                            Layout.fillWidth: true
-                            Layout.preferredHeight: 32
-                            color: "#e3f2fd"
+                    onDayClicked: function(day, month, year) {
+                        console.log("Day clicked:", day, month + 1, year);
 
-                            Text {
-                                anchors.centerIn: parent
-                                text: modelData
-                                font.bold: true
-                                font.pixelSize: 12
-                                color: "#1565C0"
-                            }
-                        }
-                    }
-
-                    // Static 5x7 day cells (placeholder)
-                    Repeater {
-                        model: 35
-                        delegate: Rectangle {
-                            Layout.fillWidth: true
-                            Layout.fillHeight: true
-                            border.color: "#eee"
-                            color: "white"
-
-                            Text {
-                                anchors.top: parent.top
-                                anchors.left: parent.left
-                                anchors.margins: 4
-                                text: {
-                                    var day = index - 5 + 1  // offset for month start
-                                    return (day >= 1 && day <= 31) ? day.toString() : ""
-                                }
-                                font.pixelSize: 11
-                                color: "#333"
-                            }
+                        // Demo: show event details for days with events
+                        var dayEvents = eventsForDay(day);
+                        if (dayEvents.length > 0) {
+                            eventDetails.loadEvent({
+                                id: "evt-" + day,
+                                title: "Sample Event on " + day,
+                                description: "This is a sample event.",
+                                location: "Conference Room A",
+                                startDate: year + "-" + (month+1) + "-" + day,
+                                startTime: "09:00",
+                                endDate: year + "-" + (month+1) + "-" + day,
+                                endTime: "10:00",
+                                allDay: false,
+                                calendarName: "Personal",
+                                calendarColor: dayEvents[0].color
+                            });
+                            showEventDetails = true;
+                        } else {
+                            showEventDetails = false;
+                            eventDetails.eventId = "";
                         }
                     }
                 }
+
+                // Event details panel (right side)
+                EventDetails {
+                    id: eventDetails
+                    Layout.preferredWidth: showEventDetails ? 280 : 0
+                    Layout.fillHeight: true
+                    visible: showEventDetails
+                    clip: true
+
+                    Behavior on Layout.preferredWidth {
+                        NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+                    }
+
+                    onEditRequested: function(evId) {
+                        eventModal.loadEvent({
+                            id: evId,
+                            title: eventDetails.eventTitle,
+                            description: eventDetails.eventDescription,
+                            location: eventDetails.eventLocation,
+                            startDate: eventDetails.eventStartDate,
+                            startTime: eventDetails.eventStartTime,
+                            endDate: eventDetails.eventEndDate,
+                            endTime: eventDetails.eventEndTime,
+                            allDay: eventDetails.eventAllDay,
+                            calendarId: ""
+                        });
+                        eventModal.open();
+                    }
+
+                    onDeleteConfirmed: function(evId) {
+                        console.log("Delete event:", evId);
+                        showEventDetails = false;
+                        eventDetails.eventId = "";
+                    }
+
+                    onCloseRequested: {
+                        showEventDetails = false;
+                        eventDetails.eventId = "";
+                    }
+                }
             }
+        }
+    }
+
+    // ── Event modal (overlay) ──────────────────────────────────────────────
+    EventModal {
+        id: eventModal
+
+        onSaveClicked: function(eventData) {
+            console.log("Event saved:", JSON.stringify(eventData));
+        }
+
+        onCancelClicked: {
+            console.log("Event creation cancelled");
         }
     }
 }

--- a/qml/EventDetails.qml
+++ b/qml/EventDetails.qml
@@ -1,0 +1,260 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Rectangle {
+    id: root
+    color: "white"
+    border.color: "#e0e0e0"
+    border.width: 1
+    radius: 8
+
+    // ── Theme ──────────────────────────────────────────────────────────────
+    property color headerColor: "#2196F3"
+    property color labelColor: "#757575"
+    property color valueColor: "#212121"
+    property color editBtnColor: "#2196F3"
+    property color deleteBtnColor: "#f44336"
+
+    // ── Event data ─────────────────────────────────────────────────────────
+    property string eventId: ""
+    property string eventTitle: ""
+    property string eventDescription: ""
+    property string eventLocation: ""
+    property string eventStartDate: ""
+    property string eventStartTime: ""
+    property string eventEndDate: ""
+    property string eventEndTime: ""
+    property bool eventAllDay: false
+    property string eventCalendarName: ""
+    property color eventCalendarColor: "#2196F3"
+
+    property bool confirmingDelete: false
+
+    signal editRequested(string eventId)
+    signal deleteConfirmed(string eventId)
+    signal closeRequested()
+
+    function loadEvent(ev) {
+        eventId = ev.id || "";
+        eventTitle = ev.title || "";
+        eventDescription = ev.description || "";
+        eventLocation = ev.location || "";
+        eventStartDate = ev.startDate || "";
+        eventStartTime = ev.startTime || "";
+        eventEndDate = ev.endDate || "";
+        eventEndTime = ev.endTime || "";
+        eventAllDay = ev.allDay || false;
+        eventCalendarName = ev.calendarName || "";
+        eventCalendarColor = ev.calendarColor || "#2196F3";
+        confirmingDelete = false;
+    }
+
+    visible: eventId !== ""
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 0
+        spacing: 0
+
+        // ── Header ─────────────────────────────────────────────────────────
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 48
+            color: eventCalendarColor
+            radius: 8
+
+            Rectangle {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: 8
+                color: eventCalendarColor
+            }
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 16
+                anchors.rightMargin: 12
+
+                Text {
+                    text: eventTitle
+                    color: "white"
+                    font.pixelSize: 16
+                    font.bold: true
+                    elide: Text.ElideRight
+                    Layout.fillWidth: true
+                }
+
+                Button {
+                    text: "X"
+                    flat: true
+                    implicitWidth: 28
+                    implicitHeight: 28
+                    onClicked: closeRequested()
+                    contentItem: Text {
+                        text: "X"; color: "white"; font.pixelSize: 14
+                        font.bold: true
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle { color: "transparent" }
+                }
+            }
+        }
+
+        // ── Details body ───────────────────────────────────────────────────
+        Flickable {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            contentHeight: detailsCol.implicitHeight
+            clip: true
+            boundsBehavior: Flickable.StopAtBounds
+
+            ColumnLayout {
+                id: detailsCol
+                width: parent.width
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: 16
+                anchors.rightMargin: 16
+                anchors.top: parent.top
+                anchors.topMargin: 16
+                spacing: 14
+
+                // Calendar
+                RowLayout {
+                    spacing: 8
+                    Rectangle {
+                        width: 10; height: 10; radius: 5
+                        color: eventCalendarColor
+                    }
+                    Text {
+                        text: eventCalendarName
+                        font.pixelSize: 13; color: labelColor
+                    }
+                }
+
+                // Date & time
+                ColumnLayout {
+                    spacing: 4
+                    Text { text: "When"; font.pixelSize: 12;
+                           font.bold: true; color: labelColor }
+                    Text {
+                        text: {
+                            var s = eventStartDate;
+                            if (!eventAllDay && eventStartTime)
+                                s += "  " + eventStartTime;
+                            if (eventEndDate) {
+                                s += "  \u2013  " + eventEndDate;
+                                if (!eventAllDay && eventEndTime)
+                                    s += "  " + eventEndTime;
+                            }
+                            if (eventAllDay) s += "  (All day)";
+                            return s;
+                        }
+                        font.pixelSize: 14; color: valueColor
+                        wrapMode: Text.Wrap
+                        Layout.fillWidth: true
+                    }
+                }
+
+                // Location
+                ColumnLayout {
+                    spacing: 4
+                    visible: eventLocation !== ""
+                    Text { text: "Location"; font.pixelSize: 12;
+                           font.bold: true; color: labelColor }
+                    Text {
+                        text: eventLocation
+                        font.pixelSize: 14; color: valueColor
+                        wrapMode: Text.Wrap
+                        Layout.fillWidth: true
+                    }
+                }
+
+                // Description
+                ColumnLayout {
+                    spacing: 4
+                    visible: eventDescription !== ""
+                    Text { text: "Description"; font.pixelSize: 12;
+                           font.bold: true; color: labelColor }
+                    Text {
+                        text: eventDescription
+                        font.pixelSize: 14; color: valueColor
+                        wrapMode: Text.Wrap
+                        Layout.fillWidth: true
+                    }
+                }
+
+                Item { Layout.fillHeight: true }
+            }
+        }
+
+        // ── Action buttons ─────────────────────────────────────────────────
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 52
+            color: "white"
+            border.color: "#eee"
+            border.width: 1
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.margins: 10
+                spacing: 8
+
+                Button {
+                    text: "Edit"
+                    onClicked: editRequested(eventId)
+                    background: Rectangle {
+                        radius: 6
+                        color: parent.pressed ? Qt.darker(editBtnColor, 1.2)
+                             : parent.hovered
+                               ? Qt.lighter(editBtnColor, 1.1)
+                               : editBtnColor
+                    }
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: "white"; font.bold: true
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                }
+
+                Item { Layout.fillWidth: true }
+
+                // Delete with confirmation
+                Button {
+                    text: confirmingDelete ? "Confirm Delete" : "Delete"
+                    onClicked: {
+                        if (confirmingDelete) {
+                            deleteConfirmed(eventId);
+                            confirmingDelete = false;
+                        } else {
+                            confirmingDelete = true;
+                        }
+                    }
+                    background: Rectangle {
+                        radius: 6
+                        color: {
+                            if (confirmingDelete)
+                                return parent.pressed
+                                    ? Qt.darker(deleteBtnColor, 1.3)
+                                    : deleteBtnColor;
+                            return parent.pressed ? "#e0e0e0"
+                                 : parent.hovered ? "#f5f5f5" : "#eeeeee";
+                        }
+                    }
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 13
+                        color: confirmingDelete ? "white" : deleteBtnColor
+                        font.bold: confirmingDelete
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qml/EventModal.qml
+++ b/qml/EventModal.qml
@@ -1,0 +1,339 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Popup {
+    id: root
+    modal: true
+    focus: true
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+    anchors.centerIn: parent
+    width: Math.min(parent.width - 40, 480)
+    height: Math.min(parent.height - 40, 560)
+    padding: 0
+
+    // ── Theme ──────────────────────────────────────────────────────────────
+    property color headerColor: "#2196F3"
+    property color fieldBg: "#f5f5f5"
+    property color fieldBorder: "#e0e0e0"
+    property color saveBtnColor: "#4CAF50"
+    property color cancelBtnColor: "#9e9e9e"
+
+    // ── Mode: "create" or "edit" ───────────────────────────────────────────
+    property string mode: "create"
+
+    // ── Form fields ────────────────────────────────────────────────────────
+    property alias eventTitle: titleField.text
+    property alias eventDescription: descField.text
+    property alias eventLocation: locationField.text
+    property bool allDay: allDaySwitch.checked
+    property string startDate: ""
+    property string startTime: ""
+    property string endDate: ""
+    property string endTime: ""
+    property string calendarId: ""
+    property string eventId: ""
+
+    signal saveClicked(var eventData)
+    signal cancelClicked()
+
+    function clear() {
+        titleField.text = "";
+        descField.text = "";
+        locationField.text = "";
+        startDateField.text = "";
+        startTimeField.text = "";
+        endDateField.text = "";
+        endTimeField.text = "";
+        allDaySwitch.checked = false;
+        mode = "create";
+        eventId = "";
+    }
+
+    function loadEvent(ev) {
+        mode = "edit";
+        eventId = ev.id || "";
+        titleField.text = ev.title || "";
+        descField.text = ev.description || "";
+        locationField.text = ev.location || "";
+        startDateField.text = ev.startDate || "";
+        startTimeField.text = ev.startTime || "";
+        endDateField.text = ev.endDate || "";
+        endTimeField.text = ev.endTime || "";
+        allDaySwitch.checked = ev.allDay || false;
+        calendarId = ev.calendarId || "";
+    }
+
+    background: Rectangle {
+        radius: 8
+        color: "white"
+        border.color: "#e0e0e0"
+    }
+
+    contentItem: ColumnLayout {
+        spacing: 0
+
+        // ── Header ─────────────────────────────────────────────────────────
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 48
+            color: headerColor
+            radius: 8
+
+            // Square off bottom corners
+            Rectangle {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: 8
+                color: headerColor
+            }
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 16
+                anchors.rightMargin: 16
+
+                Text {
+                    text: mode === "edit" ? "Edit Event" : "New Event"
+                    color: "white"
+                    font.pixelSize: 18
+                    font.bold: true
+                }
+
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "X"
+                    flat: true
+                    onClicked: { root.close(); cancelClicked(); }
+                    implicitWidth: 32
+                    implicitHeight: 32
+                    contentItem: Text {
+                        text: "X"
+                        color: "white"
+                        font.pixelSize: 16
+                        font.bold: true
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle { color: "transparent" }
+                }
+            }
+        }
+
+        // ── Form fields ────────────────────────────────────────────────────
+        Flickable {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            contentHeight: formColumn.implicitHeight
+            clip: true
+            boundsBehavior: Flickable.StopAtBounds
+
+            ColumnLayout {
+                id: formColumn
+                width: parent.width
+                spacing: 12
+                anchors.margins: 16
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: 16
+                anchors.rightMargin: 16
+                anchors.top: parent.top
+                anchors.topMargin: 12
+
+                // Title
+                Text { text: "Title *"; font.pixelSize: 13; color: "#555" }
+                TextField {
+                    id: titleField
+                    Layout.fillWidth: true
+                    placeholderText: "Event title"
+                    font.pixelSize: 14
+                    background: Rectangle {
+                        radius: 4; color: fieldBg; border.color: fieldBorder
+                    }
+                }
+
+                // All-day toggle
+                RowLayout {
+                    spacing: 8
+                    Text { text: "All day"; font.pixelSize: 13; color: "#555" }
+                    Switch { id: allDaySwitch }
+                }
+
+                // Start date / time
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        Text { text: "Start Date"; font.pixelSize: 12;
+                               color: "#555" }
+                        TextField {
+                            id: startDateField
+                            Layout.fillWidth: true
+                            placeholderText: "YYYY-MM-DD"
+                            font.pixelSize: 13
+                            background: Rectangle {
+                                radius: 4; color: fieldBg;
+                                border.color: fieldBorder
+                            }
+                        }
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        visible: !allDaySwitch.checked
+                        Text { text: "Start Time"; font.pixelSize: 12;
+                               color: "#555" }
+                        TextField {
+                            id: startTimeField
+                            Layout.fillWidth: true
+                            placeholderText: "HH:MM"
+                            font.pixelSize: 13
+                            background: Rectangle {
+                                radius: 4; color: fieldBg;
+                                border.color: fieldBorder
+                            }
+                        }
+                    }
+                }
+
+                // End date / time
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        Text { text: "End Date"; font.pixelSize: 12;
+                               color: "#555" }
+                        TextField {
+                            id: endDateField
+                            Layout.fillWidth: true
+                            placeholderText: "YYYY-MM-DD"
+                            font.pixelSize: 13
+                            background: Rectangle {
+                                radius: 4; color: fieldBg;
+                                border.color: fieldBorder
+                            }
+                        }
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        visible: !allDaySwitch.checked
+                        Text { text: "End Time"; font.pixelSize: 12;
+                               color: "#555" }
+                        TextField {
+                            id: endTimeField
+                            Layout.fillWidth: true
+                            placeholderText: "HH:MM"
+                            font.pixelSize: 13
+                            background: Rectangle {
+                                radius: 4; color: fieldBg;
+                                border.color: fieldBorder
+                            }
+                        }
+                    }
+                }
+
+                // Location
+                Text { text: "Location"; font.pixelSize: 13; color: "#555" }
+                TextField {
+                    id: locationField
+                    Layout.fillWidth: true
+                    placeholderText: "Add location"
+                    font.pixelSize: 14
+                    background: Rectangle {
+                        radius: 4; color: fieldBg; border.color: fieldBorder
+                    }
+                }
+
+                // Description
+                Text { text: "Description"; font.pixelSize: 13; color: "#555" }
+                TextArea {
+                    id: descField
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 72
+                    placeholderText: "Add description"
+                    font.pixelSize: 14
+                    wrapMode: TextArea.Wrap
+                    background: Rectangle {
+                        radius: 4; color: fieldBg; border.color: fieldBorder
+                    }
+                }
+            }
+        }
+
+        // ── Action buttons ─────────────────────────────────────────────────
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 56
+            color: "white"
+            border.color: "#eee"
+            border.width: 1
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.margins: 12
+                spacing: 8
+
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Cancel"
+                    onClicked: { root.close(); cancelClicked(); }
+                    background: Rectangle {
+                        radius: 6
+                        color: parent.pressed ? Qt.darker(cancelBtnColor, 1.2)
+                             : parent.hovered ? cancelBtnColor : "#eeeeee"
+                    }
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 14
+                        color: "#555"
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                }
+
+                Button {
+                    text: mode === "edit" ? "Save Changes" : "Create Event"
+                    enabled: titleField.text.trim().length > 0
+                    onClicked: {
+                        var data = {
+                            id: eventId,
+                            title: titleField.text,
+                            description: descField.text,
+                            location: locationField.text,
+                            startDate: startDateField.text,
+                            startTime: startTimeField.text,
+                            endDate: endDateField.text,
+                            endTime: endTimeField.text,
+                            allDay: allDaySwitch.checked,
+                            calendarId: calendarId
+                        };
+                        saveClicked(data);
+                        root.close();
+                    }
+                    background: Rectangle {
+                        radius: 6
+                        color: parent.enabled
+                            ? (parent.pressed ? Qt.darker(saveBtnColor, 1.2)
+                               : parent.hovered
+                                 ? Qt.lighter(saveBtnColor, 1.1)
+                                 : saveBtnColor)
+                            : "#cccccc"
+                    }
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 14; font.bold: true
+                        color: "white"
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements issue #6.

- **CalendarGrid**: month view with day cells, event indicators (colored dots), prev/next navigation, today highlight, day selection
- **CalendarSidebar**: calendar list with colored indicators, visibility toggle checkboxes, "New Calendar" button
- **EventModal**: create/edit event popup with title, date/time, all-day toggle, location, description fields
- **EventDetails**: read-only event detail panel with edit button and delete with confirmation
- **CalendarView**: main container wiring sidebar, grid, toolbar, details panel, and modal together

## Design
- Clean, minimal — white background with colored calendar indicators
- Qt Quick Controls 2 (Rectangle, Text, ListView, Popup, etc.)
- Responsive — works at 800x600 minimum
- Colors defined as properties for theming
- Mock data included for demo; real KV backend wired in follow-up

## Test plan
- [x] `cmake .. && make -j4` compiles cleanly
- [ ] Visual QML review with `qmlscene qml/CalendarView.qml`
- [ ] Verify month navigation (prev/next)
- [ ] Verify event modal open/close/save flow
- [ ] Verify sidebar calendar toggle and selection
- [ ] Verify event details panel slide-in on day click

🤖 Generated with [Claude Code](https://claude.com/claude-code)