### PR TITLE
feat: Logos Messaging sync layer — per-calendar topics and encryption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set_target_properties(scala_plugin PROPERTIES
 target_sources(scala_plugin PRIVATE
     src/calendar_module.cpp
     src/calendar_store.cpp
+    src/calendar_sync.cpp
     src/plugin.cpp
 )
 

--- a/metadata.json
+++ b/metadata.json
@@ -14,6 +14,6 @@
     "darwin-arm64": "scala_plugin.dylib",
     "windows-x86_64": "scala_plugin.dll"
   },
-  "dependencies": ["kv_module"],
+  "dependencies": ["kv_module", "messaging_module"],
   "capabilities": []
 }

--- a/src/calendar_module.cpp
+++ b/src/calendar_module.cpp
@@ -14,7 +14,20 @@
 // ── Construction ─────────────────────────────────────────────────────────────
 
 LogosCalendar::LogosCalendar(QObject *parent)
-    : QObject(parent) {}
+    : QObject(parent)
+    , m_sync(new CalendarSync(this))
+{
+    connect(m_sync, &CalendarSync::messageReceived,
+            this, &LogosCalendar::onSyncMessageReceived);
+    connect(m_sync, &CalendarSync::syncStarted,
+            this, [this](const QString &calendarId) {
+        emit syncStatusChanged(calendarId, QStringLiteral("syncing"));
+    });
+    connect(m_sync, &CalendarSync::syncStopped,
+            this, [this](const QString &calendarId) {
+        emit syncStatusChanged(calendarId, QStringLiteral("offline"));
+    });
+}
 
 // ── Logos Core lifecycle ─────────────────────────────────────────────────────
 
@@ -36,6 +49,15 @@ void LogosCalendar::initLogos(LogosAPI *logosAPIInstance) {
         qWarning() << "LogosCalendar: failed to get kv_module client";
     } else {
         m_store.setClient(m_kvClient);
+    }
+
+    // Get messaging module client for sync
+    m_messagingClient = m_logosAPI->getClient("messaging_module");
+    if (!m_messagingClient) {
+        qWarning() << "LogosCalendar: failed to get messaging_module client"
+                    << "(sync will use stub)";
+    } else {
+        m_sync->setMessagingClient(m_messagingClient);
     }
 
     qInfo() << "LogosCalendar: initialized. version:" << version();
@@ -70,6 +92,10 @@ QString LogosCalendar::listCalendars() {
 }
 
 bool LogosCalendar::deleteCalendar(const QString &id) {
+    // Stop sync if running before deleting
+    if (m_sync->isSyncing(id))
+        m_sync->stopSync(id);
+
     bool ok = m_store.deleteCalendar(id);
     if (ok)
         emit eventResponse("calendar_deleted", QVariantList() << id);
@@ -91,6 +117,17 @@ QString LogosCalendar::createEvent(const QString &calendarId, const QString &eve
 
     m_store.saveEvent(ev);
 
+    // Broadcast to peers if calendar is syncing
+    if (m_sync->isSyncing(calendarId)) {
+        SyncMessage msg;
+        msg.type = SyncMessageType::CreateEvent;
+        msg.calendarId = calendarId;
+        msg.payload = QString::fromUtf8(
+            QJsonDocument(ev.toJson()).toJson(QJsonDocument::Compact));
+        msg.timestamp = now;
+        m_sync->sendMessage(calendarId, msg);
+    }
+
     emit eventResponse("event_created", QVariantList() << ev.id << calendarId);
     return ev.id;
 }
@@ -103,15 +140,37 @@ bool LogosCalendar::updateEvent(const QString &eventJson) {
     ev.updatedAt = QDateTime::currentMSecsSinceEpoch();
 
     bool ok = m_store.updateEvent(ev);
-    if (ok)
+    if (ok) {
+        // Broadcast to peers if calendar is syncing
+        if (m_sync->isSyncing(ev.calendarId)) {
+            SyncMessage msg;
+            msg.type = SyncMessageType::UpdateEvent;
+            msg.calendarId = ev.calendarId;
+            msg.payload = QString::fromUtf8(
+                QJsonDocument(ev.toJson()).toJson(QJsonDocument::Compact));
+            msg.timestamp = ev.updatedAt;
+            m_sync->sendMessage(ev.calendarId, msg);
+        }
         emit eventResponse("event_updated", QVariantList() << ev.id);
+    }
     return ok;
 }
 
 bool LogosCalendar::deleteEvent(const QString &id) {
+    // Get event before deleting to know the calendarId
+    auto ev = m_store.getEvent(id);
     bool ok = m_store.deleteEvent(id);
-    if (ok)
+    if (ok) {
+        if (!ev.calendarId.isEmpty() && m_sync->isSyncing(ev.calendarId)) {
+            SyncMessage msg;
+            msg.type = SyncMessageType::DeleteEvent;
+            msg.calendarId = ev.calendarId;
+            msg.payload = id;
+            msg.timestamp = QDateTime::currentMSecsSinceEpoch();
+            m_sync->sendMessage(ev.calendarId, msg);
+        }
         emit eventResponse("event_deleted", QVariantList() << id);
+    }
     return ok;
 }
 
@@ -129,4 +188,138 @@ QString LogosCalendar::getEvent(const QString &id) {
         return {};
     return QString::fromUtf8(
         QJsonDocument(ev.toJson()).toJson(QJsonDocument::Compact));
+}
+
+// ── Sync API ─────────────────────────────────────────────────────────────────
+
+QString LogosCalendar::shareCalendar(const QString &calendarId) {
+    auto cal = m_store.getCalendar(calendarId);
+    if (cal.id.isEmpty())
+        return {};
+
+    // Generate encryption key if not already shared
+    if (cal.encryptionKey.isEmpty()) {
+        cal.encryptionKey = QUuid::createUuid().toString(QUuid::WithoutBraces)
+                          + QUuid::createUuid().toString(QUuid::WithoutBraces);
+    }
+    cal.isShared = true;
+    cal.updatedAt = QDateTime::currentMSecsSinceEpoch();
+    m_store.saveCalendar(cal);
+
+    m_sync->startSync(calendarId, cal.encryptionKey);
+
+    emit eventResponse("calendar_shared", QVariantList() << calendarId);
+    return cal.encryptionKey;
+}
+
+bool LogosCalendar::joinSharedCalendar(const QString &calendarId,
+                                       const QString &encryptionKey) {
+    if (calendarId.isEmpty() || encryptionKey.isEmpty())
+        return false;
+
+    // Create local calendar entry if it doesn't exist
+    auto cal = m_store.getCalendar(calendarId);
+    if (cal.id.isEmpty()) {
+        cal.id = calendarId;
+        cal.name = QStringLiteral("Shared Calendar");
+        cal.color = QStringLiteral("#9C27B0");
+        cal.isShared = true;
+        cal.encryptionKey = encryptionKey;
+        qint64 now = QDateTime::currentMSecsSinceEpoch();
+        cal.createdAt = now;
+        cal.updatedAt = now;
+        m_store.saveCalendar(cal);
+    } else {
+        cal.isShared = true;
+        cal.encryptionKey = encryptionKey;
+        cal.updatedAt = QDateTime::currentMSecsSinceEpoch();
+        m_store.saveCalendar(cal);
+    }
+
+    m_sync->startSync(calendarId, encryptionKey);
+
+    // Request bulk sync from peers
+    SyncMessage msg;
+    msg.type = SyncMessageType::SyncEvents;
+    msg.calendarId = calendarId;
+    msg.timestamp = QDateTime::currentMSecsSinceEpoch();
+    m_sync->sendMessage(calendarId, msg);
+
+    emit eventResponse("calendar_joined", QVariantList() << calendarId);
+    return true;
+}
+
+QString LogosCalendar::getSyncStatus(const QString &calendarId) {
+    auto cal = m_store.getCalendar(calendarId);
+    if (cal.id.isEmpty() || !cal.isShared)
+        return QStringLiteral("not_shared");
+
+    if (m_sync->isSyncing(calendarId))
+        return QStringLiteral("syncing");
+
+    return QStringLiteral("offline");
+}
+
+// ── Incoming sync messages ───────────────────────────────────────────────────
+
+void LogosCalendar::onSyncMessageReceived(const QString &calendarId,
+                                           const SyncMessage &msg) {
+    switch (msg.type) {
+    case SyncMessageType::CreateEvent: {
+        QJsonDocument doc = QJsonDocument::fromJson(msg.payload.toUtf8());
+        scala::CalendarEvent ev = scala::CalendarEvent::fromJson(doc.object());
+        if (!ev.id.isEmpty()) {
+            m_store.saveEvent(ev);
+            emit eventResponse("event_created", QVariantList() << ev.id << calendarId);
+        }
+        break;
+    }
+    case SyncMessageType::UpdateEvent: {
+        QJsonDocument doc = QJsonDocument::fromJson(msg.payload.toUtf8());
+        scala::CalendarEvent ev = scala::CalendarEvent::fromJson(doc.object());
+        if (!ev.id.isEmpty()) {
+            m_store.updateEvent(ev);
+            emit eventResponse("event_updated", QVariantList() << ev.id);
+        }
+        break;
+    }
+    case SyncMessageType::DeleteEvent: {
+        QString eventId = msg.payload;
+        if (!eventId.isEmpty()) {
+            m_store.deleteEvent(eventId);
+            emit eventResponse("event_deleted", QVariantList() << eventId);
+        }
+        break;
+    }
+    case SyncMessageType::SyncEvents: {
+        // Peer is requesting bulk sync — send all events for this calendar
+        auto events = m_store.listEvents(calendarId);
+        for (const auto &ev : events) {
+            SyncMessage reply;
+            reply.type = SyncMessageType::CreateEvent;
+            reply.calendarId = calendarId;
+            reply.payload = QString::fromUtf8(
+                QJsonDocument(ev.toJson()).toJson(QJsonDocument::Compact));
+            reply.timestamp = QDateTime::currentMSecsSinceEpoch();
+            m_sync->sendMessage(calendarId, reply);
+        }
+        break;
+    }
+    case SyncMessageType::UnshareCalendar: {
+        m_sync->stopSync(calendarId);
+        auto cal = m_store.getCalendar(calendarId);
+        if (!cal.id.isEmpty()) {
+            cal.isShared = false;
+            cal.encryptionKey.clear();
+            cal.updatedAt = QDateTime::currentMSecsSinceEpoch();
+            m_store.saveCalendar(cal);
+        }
+        emit eventResponse("calendar_unshared", QVariantList() << calendarId);
+        break;
+    }
+    case SyncMessageType::CalendarReconnected: {
+        qDebug() << "CalendarSync: peer reconnected for" << calendarId;
+        break;
+    }
+    }
 }

--- a/src/calendar_module.h
+++ b/src/calendar_module.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "calendar_store.h"
+#include "calendar_sync.h"
 #include "types.h"
 
 #include <QObject>
@@ -26,6 +27,12 @@ public:
     virtual bool deleteEvent(const QString &id) = 0;
     virtual QString listEvents(const QString &calendarId) = 0;
     virtual QString getEvent(const QString &id) = 0;
+
+    // ── Sync API ───────────────────────────────────────────────────────────
+    virtual QString shareCalendar(const QString &calendarId) = 0;
+    virtual bool joinSharedCalendar(const QString &calendarId,
+                                    const QString &encryptionKey) = 0;
+    virtual QString getSyncStatus(const QString &calendarId) = 0;
 };
 
 #define ILogosCalendar_iid "com.logos.module.ILogosCalendar"
@@ -70,14 +77,25 @@ public:
     Q_INVOKABLE QString listEvents(const QString &calendarId) override;
     Q_INVOKABLE QString getEvent(const QString &id) override;
 
+    // ── Sync API ────────────────────────────────────────────────────────────
+    Q_INVOKABLE QString shareCalendar(const QString &calendarId) override;
+    Q_INVOKABLE bool joinSharedCalendar(const QString &calendarId,
+                                        const QString &encryptionKey) override;
+    Q_INVOKABLE QString getSyncStatus(const QString &calendarId) override;
+
 signals:
     void eventResponse(const QString &eventName, const QVariantList &args);
+    void syncStatusChanged(const QString &calendarId, const QString &status);
 
 private:
+    void onSyncMessageReceived(const QString &calendarId, const SyncMessage &msg);
+
     CalendarStore m_store;
+    CalendarSync *m_sync = nullptr;
 
 #ifdef LOGOS_CORE_AVAILABLE
     LogosAPI *m_logosAPI = nullptr;
     LogosAPIClient *m_kvClient = nullptr;
+    LogosAPIClient *m_messagingClient = nullptr;
 #endif
 };

--- a/src/calendar_sync.cpp
+++ b/src/calendar_sync.cpp
@@ -1,0 +1,161 @@
+#include "calendar_sync.h"
+
+#ifdef LOGOS_CORE_AVAILABLE
+#include <logos_api_client.h>
+#endif
+
+#include <QDebug>
+#include <QJsonDocument>
+
+// ── SyncMessage helpers ─────────────────────────────────────────────────────
+
+QString SyncMessage::typeToString(SyncMessageType t) {
+    switch (t) {
+    case SyncMessageType::CreateEvent:         return QStringLiteral("CreateEvent");
+    case SyncMessageType::UpdateEvent:         return QStringLiteral("UpdateEvent");
+    case SyncMessageType::DeleteEvent:         return QStringLiteral("DeleteEvent");
+    case SyncMessageType::SyncEvents:          return QStringLiteral("SyncEvents");
+    case SyncMessageType::UnshareCalendar:     return QStringLiteral("UnshareCalendar");
+    case SyncMessageType::CalendarReconnected: return QStringLiteral("CalendarReconnected");
+    }
+    return QStringLiteral("CreateEvent");
+}
+
+SyncMessageType SyncMessage::typeFromString(const QString &s) {
+    if (s == QLatin1String("CreateEvent"))         return SyncMessageType::CreateEvent;
+    if (s == QLatin1String("UpdateEvent"))         return SyncMessageType::UpdateEvent;
+    if (s == QLatin1String("DeleteEvent"))         return SyncMessageType::DeleteEvent;
+    if (s == QLatin1String("SyncEvents"))          return SyncMessageType::SyncEvents;
+    if (s == QLatin1String("UnshareCalendar"))     return SyncMessageType::UnshareCalendar;
+    if (s == QLatin1String("CalendarReconnected")) return SyncMessageType::CalendarReconnected;
+    return SyncMessageType::CreateEvent;
+}
+
+QJsonObject SyncMessage::toJson() const {
+    QJsonObject obj;
+    obj[QLatin1String("type")]       = typeToString(type);
+    obj[QLatin1String("calendarId")] = calendarId;
+    obj[QLatin1String("payload")]    = payload;
+    obj[QLatin1String("senderId")]   = senderId;
+    obj[QLatin1String("timestamp")]  = timestamp;
+    return obj;
+}
+
+SyncMessage SyncMessage::fromJson(const QJsonObject &obj) {
+    SyncMessage msg;
+    msg.type       = typeFromString(obj[QLatin1String("type")].toString());
+    msg.calendarId = obj[QLatin1String("calendarId")].toString();
+    msg.payload    = obj[QLatin1String("payload")].toString();
+    msg.senderId   = obj[QLatin1String("senderId")].toString();
+    msg.timestamp  = static_cast<qint64>(obj[QLatin1String("timestamp")].toDouble());
+    return msg;
+}
+
+QByteArray SyncMessage::toBytes() const {
+    return QJsonDocument(toJson()).toJson(QJsonDocument::Compact);
+}
+
+SyncMessage SyncMessage::fromBytes(const QByteArray &data) {
+    QJsonDocument doc = QJsonDocument::fromJson(data);
+    return fromJson(doc.object());
+}
+
+// ── CalendarSync ────────────────────────────────────────────────────────────
+
+CalendarSync::CalendarSync(QObject *parent)
+    : QObject(parent) {}
+
+QString CalendarSync::topicForCalendar(const QString &calendarId) {
+    return QStringLiteral("/scala/1/") + calendarId + QStringLiteral("/json");
+}
+
+bool CalendarSync::isSyncing(const QString &calendarId) const {
+    return m_activeTopics.contains(calendarId);
+}
+
+#ifdef LOGOS_CORE_AVAILABLE
+void CalendarSync::setMessagingClient(LogosAPIClient *client) {
+    m_messagingClient = client;
+}
+#endif
+
+void CalendarSync::startSync(const QString &calendarId, const QString &encryptionKey) {
+    if (m_activeTopics.contains(calendarId)) {
+        qDebug() << "CalendarSync: already syncing" << calendarId;
+        return;
+    }
+
+    const QString topic = topicForCalendar(calendarId);
+    m_activeTopics.insert(calendarId, encryptionKey);
+
+#ifdef LOGOS_CORE_AVAILABLE
+    if (m_messagingClient) {
+        // Subscribe to the topic via the messaging module
+        m_messagingClient->invokeRemoteMethod(
+            "messaging_module", "subscribe", topic, encryptionKey);
+
+        qInfo() << "CalendarSync: subscribed to topic" << topic;
+        emit syncStarted(calendarId);
+        return;
+    }
+    qWarning() << "CalendarSync: no messaging client, falling back to stub";
+#endif
+
+    // Stub: emit syncStarted immediately for testing without Logos Core
+    qDebug() << "CalendarSync [stub]: startSync" << calendarId
+             << "topic:" << topic;
+    emit syncStarted(calendarId);
+}
+
+void CalendarSync::stopSync(const QString &calendarId) {
+    if (!m_activeTopics.contains(calendarId)) {
+        qDebug() << "CalendarSync: not syncing" << calendarId;
+        return;
+    }
+
+    const QString topic = topicForCalendar(calendarId);
+    m_activeTopics.remove(calendarId);
+
+#ifdef LOGOS_CORE_AVAILABLE
+    if (m_messagingClient) {
+        m_messagingClient->invokeRemoteMethod(
+            "messaging_module", "unsubscribe", topic);
+
+        qInfo() << "CalendarSync: unsubscribed from topic" << topic;
+        emit syncStopped(calendarId);
+        return;
+    }
+#endif
+
+    qDebug() << "CalendarSync [stub]: stopSync" << calendarId;
+    emit syncStopped(calendarId);
+}
+
+void CalendarSync::sendMessage(const QString &calendarId, const SyncMessage &msg) {
+    if (!m_activeTopics.contains(calendarId)) {
+        emit syncError(calendarId,
+                       QStringLiteral("Cannot send: calendar not syncing"));
+        return;
+    }
+
+    const QString topic = topicForCalendar(calendarId);
+    const QByteArray data = msg.toBytes();
+
+#ifdef LOGOS_CORE_AVAILABLE
+    if (m_messagingClient) {
+        const QString &encryptionKey = m_activeTopics.value(calendarId);
+        m_messagingClient->invokeRemoteMethod(
+            "messaging_module", "publish", topic, data, encryptionKey);
+
+        qDebug() << "CalendarSync: published" << SyncMessage::typeToString(msg.type)
+                 << "to" << topic << "(" << data.size() << "bytes)";
+        return;
+    }
+#endif
+
+    // Stub: log the message for debugging
+    qDebug() << "CalendarSync [stub]: sendMessage"
+             << SyncMessage::typeToString(msg.type)
+             << "calendarId:" << calendarId
+             << "payload size:" << data.size();
+}

--- a/src/calendar_sync.h
+++ b/src/calendar_sync.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <QByteArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMap>
+#include <QObject>
+#include <QString>
+
+#ifdef LOGOS_CORE_AVAILABLE
+class LogosAPIClient;
+#endif
+
+// ── Sync message types (mirror original js-waku types) ──────────────────────
+
+enum class SyncMessageType {
+    CreateEvent,
+    UpdateEvent,
+    DeleteEvent,
+    SyncEvents,          // bulk sync on join
+    UnshareCalendar,
+    CalendarReconnected
+};
+
+// ── SyncMessage ─────────────────────────────────────────────────────────────
+
+struct SyncMessage {
+    SyncMessageType type = SyncMessageType::CreateEvent;
+    QString calendarId;
+    QString payload;     // JSON-encoded CalendarEvent or empty
+    QString senderId;    // Logos identity pubkey
+    qint64 timestamp = 0;
+
+    QJsonObject toJson() const;
+    static SyncMessage fromJson(const QJsonObject &obj);
+    QByteArray toBytes() const;
+    static SyncMessage fromBytes(const QByteArray &data);
+
+    static QString typeToString(SyncMessageType t);
+    static SyncMessageType typeFromString(const QString &s);
+};
+
+// ── CalendarSync ────────────────────────────────────────────────────────────
+
+class CalendarSync : public QObject {
+    Q_OBJECT
+
+public:
+    explicit CalendarSync(QObject *parent = nullptr);
+
+    /// Start syncing a calendar (subscribe to its topic).
+    void startSync(const QString &calendarId, const QString &encryptionKey);
+
+    /// Stop syncing a calendar.
+    void stopSync(const QString &calendarId);
+
+    /// Send a sync message for a calendar.
+    void sendMessage(const QString &calendarId, const SyncMessage &msg);
+
+    /// Whether a calendar is currently syncing.
+    bool isSyncing(const QString &calendarId) const;
+
+    /// Topic format: /scala/1/<calendarId>/json
+    static QString topicForCalendar(const QString &calendarId);
+
+#ifdef LOGOS_CORE_AVAILABLE
+    void setMessagingClient(LogosAPIClient *client);
+#endif
+
+signals:
+    void messageReceived(const QString &calendarId, const SyncMessage &msg);
+    void syncStarted(const QString &calendarId);
+    void syncStopped(const QString &calendarId);
+    void syncError(const QString &calendarId, const QString &error);
+
+private:
+    // calendarId -> encryption key
+    QMap<QString, QString> m_activeTopics;
+
+#ifdef LOGOS_CORE_AVAILABLE
+    LogosAPIClient *m_messagingClient = nullptr;
+#endif
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,3 +26,24 @@ target_link_libraries(test_calendar PRIVATE
 )
 
 add_test(NAME test_calendar COMMAND test_calendar)
+
+# ── Sync tests ───────────────────────────────────────────────────────────────
+
+add_executable(test_sync
+    test_sync.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/calendar_sync.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/calendar_store.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/calendar_module.cpp
+)
+
+target_include_directories(test_sync PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+target_link_libraries(test_sync PRIVATE
+    Qt6::Core
+    Qt6::Test
+)
+
+add_test(NAME test_sync COMMAND test_sync)

--- a/tests/test_sync.cpp
+++ b/tests/test_sync.cpp
@@ -1,0 +1,205 @@
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSignalSpy>
+#include <QTest>
+
+#include "calendar_sync.h"
+#include "calendar_module.h"
+
+// ── SyncMessage tests ───────────────────────────────────────────────────────
+
+class TestSync : public QObject {
+    Q_OBJECT
+
+private slots:
+    void syncMessageJsonRoundtrip();
+    void syncMessageBytesRoundtrip();
+    void syncMessageAllTypes();
+    void syncMessageFromEmptyJson();
+    void topicForCalendarFormat();
+    void topicForCalendarDifferentIds();
+    void calendarSyncStartStop();
+    void calendarSyncSendWithoutSync();
+    void shareCalendarGeneratesKey();
+    void shareCalendarIdempotent();
+    void joinSharedCalendar();
+    void getSyncStatusValues();
+};
+
+void TestSync::syncMessageJsonRoundtrip() {
+    SyncMessage msg;
+    msg.type = SyncMessageType::CreateEvent;
+    msg.calendarId = "cal-001";
+    msg.payload = R"({"title":"Meeting"})";
+    msg.senderId = "pubkey_alice";
+    msg.timestamp = 1700000000000LL;
+
+    QJsonObject json = msg.toJson();
+    SyncMessage restored = SyncMessage::fromJson(json);
+
+    QCOMPARE(restored.type, msg.type);
+    QCOMPARE(restored.calendarId, msg.calendarId);
+    QCOMPARE(restored.payload, msg.payload);
+    QCOMPARE(restored.senderId, msg.senderId);
+    QCOMPARE(restored.timestamp, msg.timestamp);
+}
+
+void TestSync::syncMessageBytesRoundtrip() {
+    SyncMessage msg;
+    msg.type = SyncMessageType::UpdateEvent;
+    msg.calendarId = "cal-002";
+    msg.payload = R"({"id":"evt-1","title":"Updated"})";
+    msg.senderId = "pubkey_bob";
+    msg.timestamp = 1700000001000LL;
+
+    QByteArray bytes = msg.toBytes();
+    QVERIFY(!bytes.isEmpty());
+
+    SyncMessage restored = SyncMessage::fromBytes(bytes);
+
+    QCOMPARE(restored.type, SyncMessageType::UpdateEvent);
+    QCOMPARE(restored.calendarId, msg.calendarId);
+    QCOMPARE(restored.payload, msg.payload);
+    QCOMPARE(restored.senderId, msg.senderId);
+    QCOMPARE(restored.timestamp, msg.timestamp);
+}
+
+void TestSync::syncMessageAllTypes() {
+    // Verify all message types roundtrip through string conversion
+    QList<SyncMessageType> types = {
+        SyncMessageType::CreateEvent,
+        SyncMessageType::UpdateEvent,
+        SyncMessageType::DeleteEvent,
+        SyncMessageType::SyncEvents,
+        SyncMessageType::UnshareCalendar,
+        SyncMessageType::CalendarReconnected
+    };
+
+    for (auto t : types) {
+        SyncMessage msg;
+        msg.type = t;
+        msg.calendarId = "cal-test";
+        msg.timestamp = 1700000000000LL;
+
+        QJsonObject json = msg.toJson();
+        SyncMessage restored = SyncMessage::fromJson(json);
+        QCOMPARE(restored.type, t);
+    }
+}
+
+void TestSync::syncMessageFromEmptyJson() {
+    QJsonObject emptyObj;
+    SyncMessage msg = SyncMessage::fromJson(emptyObj);
+
+    // Defaults
+    QCOMPARE(msg.type, SyncMessageType::CreateEvent);
+    QVERIFY(msg.calendarId.isEmpty());
+    QVERIFY(msg.payload.isEmpty());
+    QVERIFY(msg.senderId.isEmpty());
+    QCOMPARE(msg.timestamp, 0LL);
+}
+
+void TestSync::topicForCalendarFormat() {
+    QString topic = CalendarSync::topicForCalendar("abc-123");
+    QCOMPARE(topic, QStringLiteral("/scala/1/abc-123/json"));
+}
+
+void TestSync::topicForCalendarDifferentIds() {
+    QString t1 = CalendarSync::topicForCalendar("id-1");
+    QString t2 = CalendarSync::topicForCalendar("id-2");
+
+    QVERIFY(t1 != t2);
+    QVERIFY(t1.startsWith("/scala/1/"));
+    QVERIFY(t1.endsWith("/json"));
+    QVERIFY(t2.startsWith("/scala/1/"));
+    QVERIFY(t2.endsWith("/json"));
+}
+
+void TestSync::calendarSyncStartStop() {
+    CalendarSync sync;
+    QSignalSpy startedSpy(&sync, &CalendarSync::syncStarted);
+    QSignalSpy stoppedSpy(&sync, &CalendarSync::syncStopped);
+
+    QVERIFY(!sync.isSyncing("cal-001"));
+
+    sync.startSync("cal-001", "key123");
+    QVERIFY(sync.isSyncing("cal-001"));
+    QCOMPARE(startedSpy.count(), 1);
+    QCOMPARE(startedSpy.at(0).at(0).toString(), QStringLiteral("cal-001"));
+
+    // Starting again should be a no-op
+    sync.startSync("cal-001", "key123");
+    QCOMPARE(startedSpy.count(), 1);
+
+    sync.stopSync("cal-001");
+    QVERIFY(!sync.isSyncing("cal-001"));
+    QCOMPARE(stoppedSpy.count(), 1);
+}
+
+void TestSync::calendarSyncSendWithoutSync() {
+    CalendarSync sync;
+    QSignalSpy errorSpy(&sync, &CalendarSync::syncError);
+
+    SyncMessage msg;
+    msg.type = SyncMessageType::CreateEvent;
+    msg.calendarId = "cal-not-syncing";
+
+    sync.sendMessage("cal-not-syncing", msg);
+    QCOMPARE(errorSpy.count(), 1);
+}
+
+void TestSync::shareCalendarGeneratesKey() {
+    LogosCalendar module;
+
+    // Create a calendar first
+    QString calId = module.createCalendar("Team", "#FF0000");
+    QVERIFY(!calId.isEmpty());
+
+    // Share it
+    QString key = module.shareCalendar(calId);
+    QVERIFY(!key.isEmpty());
+
+    // Verify sync status
+    QCOMPARE(module.getSyncStatus(calId), QStringLiteral("syncing"));
+}
+
+void TestSync::shareCalendarIdempotent() {
+    LogosCalendar module;
+
+    QString calId = module.createCalendar("Team", "#00FF00");
+    QString key1 = module.shareCalendar(calId);
+    QString key2 = module.shareCalendar(calId);
+
+    // Same key returned on re-share
+    QCOMPARE(key1, key2);
+}
+
+void TestSync::joinSharedCalendar() {
+    LogosCalendar module;
+
+    bool ok = module.joinSharedCalendar("remote-cal-123", "someEncryptionKey");
+    QVERIFY(ok);
+    QCOMPARE(module.getSyncStatus("remote-cal-123"), QStringLiteral("syncing"));
+
+    // Reject empty params
+    QVERIFY(!module.joinSharedCalendar("", "key"));
+    QVERIFY(!module.joinSharedCalendar("id", ""));
+}
+
+void TestSync::getSyncStatusValues() {
+    LogosCalendar module;
+
+    // Non-existent calendar
+    QCOMPARE(module.getSyncStatus("nonexistent"), QStringLiteral("not_shared"));
+
+    // Created but not shared
+    QString calId = module.createCalendar("Private", "#0000FF");
+    QCOMPARE(module.getSyncStatus(calId), QStringLiteral("not_shared"));
+
+    // After sharing
+    module.shareCalendar(calId);
+    QCOMPARE(module.getSyncStatus(calId), QStringLiteral("syncing"));
+}
+
+QTEST_MAIN(TestSync)
+#include "test_sync.moc"


### PR DESCRIPTION
## Summary

Implements issue #3 — Logos Messaging sync layer for P2P calendar synchronization.

- **CalendarSync class** with per-calendar topic management (`/scala/1/<calendarId>/json`)
- **SyncMessage types**: `CreateEvent`, `UpdateEvent`, `DeleteEvent`, `SyncEvents`, `UnshareCalendar`, `CalendarReconnected`
- **Inter-module calls** via `logosAPI->getClient("messaging_module")` — no direct Waku/C++ dependencies
- **LOGOS_CORE_AVAILABLE guard** — real QtRO calls when running in Logos Core, clean stub for standalone/test builds
- **Public API**: `shareCalendar()`, `joinSharedCalendar()`, `getSyncStatus()`
- **Auto-broadcast**: event create/update/delete operations broadcast to peers on shared calendars
- **Incoming message handler**: processes remote events, handles bulk sync requests
- **Tests**: SyncMessage JSON/bytes roundtrip, topic format, share/join flow, sync status

## Architecture

```
LogosCalendar (calendar_module)
  ├── CalendarStore  → kv_module (via QtRO)
  └── CalendarSync   → messaging_module (via QtRO)
       ├── startSync(calendarId, encryptionKey)
       ├── stopSync(calendarId)
       └── sendMessage(calendarId, SyncMessage)
```

## Test plan

- [x] SyncMessage JSON roundtrip (all 6 types)
- [x] SyncMessage bytes serialization roundtrip
- [x] Topic format: `/scala/1/<calendarId>/json`
- [x] CalendarSync start/stop lifecycle
- [x] Error on send without active sync
- [x] shareCalendar() generates non-empty key
- [x] shareCalendar() is idempotent (same key on re-share)
- [x] joinSharedCalendar() creates local calendar entry
- [x] getSyncStatus() returns correct values
- [x] Full build passes (cmake + make)
- [ ] Integration test with real Logos Core (pending messaging_module availability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)