### PR TITLE
feat: calendar sharing — invite link, QR placeholder, join flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(scala_plugin PRIVATE
     src/calendar_module.cpp
     src/calendar_store.cpp
     src/calendar_sync.cpp
+    src/qr_generator.cpp
     src/plugin.cpp
 )
 
@@ -107,6 +108,7 @@ if(BUILD_STANDALONE)
             qml/CalendarSidebar.qml
             qml/EventModal.qml
             qml/EventDetails.qml
+            qml/ShareDialog.qml
     )
 
     target_link_libraries(scala_standalone PRIVATE

--- a/qml/CalendarSidebar.qml
+++ b/qml/CalendarSidebar.qml
@@ -20,6 +20,7 @@ Rectangle {
     signal calendarToggled(string calendarId, bool visible)
     signal newCalendarRequested()
     signal calendarSelected(string calendarId)
+    signal shareRequested(string calendarId, string calendarName)
 
     // ── Default calendars (mock) ───────────────────────────────────────────
     ListModel {
@@ -94,6 +95,23 @@ Rectangle {
                         color: titleColor
                         elide: Text.ElideRight
                         Layout.fillWidth: true
+                    }
+
+                    // Share button
+                    Button {
+                        implicitWidth: 28
+                        implicitHeight: 28
+                        flat: true
+                        text: "\u21AA"
+                        font.pixelSize: 14
+                        ToolTip.visible: hovered
+                        ToolTip.text: "Share"
+                        onClicked: shareRequested(calId, calName)
+
+                        background: Rectangle {
+                            radius: 4
+                            color: parent.hovered ? "#e3f2fd" : "transparent"
+                        }
                     }
 
                     // Visibility toggle

--- a/qml/ShareDialog.qml
+++ b/qml/ShareDialog.qml
@@ -1,0 +1,242 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Popup {
+    id: shareDialog
+    modal: true
+    anchors.centerIn: parent
+    width: 420
+    height: 480
+    padding: 20
+
+    // ── Properties ──────────────────────────────────────────────────────────
+    property string shareLink: ""
+    property string qrDataUrl: ""
+    property string calendarName: ""
+
+    signal joinRequested(string link)
+
+    background: Rectangle {
+        radius: 12
+        color: "white"
+        border.color: "#e0e0e0"
+        border.width: 1
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 12
+
+        // ── Title ───────────────────────────────────────────────────────────
+        Text {
+            text: "Share Calendar"
+            font.pixelSize: 18
+            font.bold: true
+            color: "#212121"
+            Layout.fillWidth: true
+        }
+
+        Text {
+            text: calendarName
+            font.pixelSize: 14
+            color: "#757575"
+            Layout.fillWidth: true
+            visible: calendarName.length > 0
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            height: 1
+            color: "#e0e0e0"
+        }
+
+        // ── Tab bar ─────────────────────────────────────────────────────────
+        TabBar {
+            id: tabBar
+            Layout.fillWidth: true
+
+            TabButton {
+                text: "Share"
+                width: implicitWidth
+            }
+            TabButton {
+                text: "Join"
+                width: implicitWidth
+            }
+        }
+
+        // ── Tab content ─────────────────────────────────────────────────────
+        StackLayout {
+            currentIndex: tabBar.currentIndex
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            // ── Share tab ───────────────────────────────────────────────────
+            ColumnLayout {
+                spacing: 12
+
+                Text {
+                    text: "Share this link to invite others:"
+                    font.pixelSize: 13
+                    color: "#424242"
+                }
+
+                // Link text field (read-only, selectable)
+                TextField {
+                    id: linkField
+                    Layout.fillWidth: true
+                    text: shareLink
+                    readOnly: true
+                    selectByMouse: true
+                    wrapMode: TextInput.WrapAnywhere
+                    font.pixelSize: 12
+                    font.family: "monospace"
+
+                    background: Rectangle {
+                        radius: 6
+                        color: "#f5f5f5"
+                        border.color: "#e0e0e0"
+                        border.width: 1
+                    }
+                }
+
+                // Copy Link button
+                Button {
+                    Layout.fillWidth: true
+                    text: copyTimer.running ? "Copied!" : "Copy Link"
+
+                    onClicked: {
+                        linkField.selectAll()
+                        linkField.copy()
+                        linkField.deselect()
+                        copyTimer.start()
+                    }
+
+                    Timer {
+                        id: copyTimer
+                        interval: 2000
+                    }
+
+                    background: Rectangle {
+                        radius: 6
+                        color: parent.pressed ? "#1976D2"
+                             : parent.hovered ? "#42A5F5"
+                             : "#2196F3"
+                    }
+
+                    contentItem: Text {
+                        text: parent.text
+                        color: "white"
+                        font.pixelSize: 13
+                        font.bold: true
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                }
+
+                // QR code placeholder
+                Image {
+                    Layout.alignment: Qt.AlignHCenter
+                    width: 160
+                    height: 160
+                    source: qrDataUrl
+                    visible: qrDataUrl.length > 0
+                    fillMode: Image.PreserveAspectFit
+                }
+
+                // Fallback text when no QR data URL
+                Text {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: "(QR code placeholder)"
+                    font.pixelSize: 11
+                    color: "#bdbdbd"
+                    visible: qrDataUrl.length === 0
+                }
+
+                Item { Layout.fillHeight: true }
+            }
+
+            // ── Join tab ────────────────────────────────────────────────────
+            ColumnLayout {
+                spacing: 12
+
+                Text {
+                    text: "Paste a share link to join a calendar:"
+                    font.pixelSize: 13
+                    color: "#424242"
+                }
+
+                TextField {
+                    id: joinLinkField
+                    Layout.fillWidth: true
+                    placeholderText: "scala://join?id=...&key=...&name=..."
+                    selectByMouse: true
+                    font.pixelSize: 12
+                    font.family: "monospace"
+
+                    background: Rectangle {
+                        radius: 6
+                        color: "white"
+                        border.color: joinLinkField.activeFocus ? "#2196F3" : "#e0e0e0"
+                        border.width: 1
+                    }
+                }
+
+                Text {
+                    id: joinError
+                    Layout.fillWidth: true
+                    color: "#D32F2F"
+                    font.pixelSize: 12
+                    visible: text.length > 0
+                }
+
+                Button {
+                    Layout.fillWidth: true
+                    text: "Join Calendar"
+                    enabled: joinLinkField.text.length > 0
+
+                    onClicked: {
+                        joinError.text = ""
+                        joinRequested(joinLinkField.text)
+                    }
+
+                    background: Rectangle {
+                        radius: 6
+                        color: !parent.enabled ? "#BDBDBD"
+                             : parent.pressed ? "#388E3C"
+                             : parent.hovered ? "#66BB6A"
+                             : "#4CAF50"
+                    }
+
+                    contentItem: Text {
+                        text: parent.text
+                        color: "white"
+                        font.pixelSize: 13
+                        font.bold: true
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                }
+
+                Item { Layout.fillHeight: true }
+            }
+        }
+
+        // ── Close button ────────────────────────────────────────────────────
+        Button {
+            Layout.fillWidth: true
+            text: "Close"
+            flat: true
+            onClicked: shareDialog.close()
+
+            contentItem: Text {
+                text: parent.text
+                color: "#757575"
+                font.pixelSize: 13
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+            }
+        }
+    }
+}

--- a/src/calendar_module.cpp
+++ b/src/calendar_module.cpp
@@ -9,6 +9,8 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QUrl>
+#include <QUrlQuery>
 #include <QUuid>
 
 // ── Construction ─────────────────────────────────────────────────────────────
@@ -258,6 +260,96 @@ QString LogosCalendar::getSyncStatus(const QString &calendarId) {
         return QStringLiteral("syncing");
 
     return QStringLiteral("offline");
+}
+
+// ── Share link API ───────────────────────────────────────────────────────────
+
+QString LogosCalendar::generateShareLink(const QString &calendarId) {
+    auto cal = m_store.getCalendar(calendarId);
+    if (cal.id.isEmpty())
+        return {};
+
+    // Ensure calendar is shared (generates key if needed)
+    if (!cal.isShared || cal.encryptionKey.isEmpty())
+        shareCalendar(calendarId);
+
+    // Re-read after shareCalendar may have updated the key
+    cal = m_store.getCalendar(calendarId);
+    if (cal.encryptionKey.isEmpty())
+        return {};
+
+    QByteArray base64Key = cal.encryptionKey.toUtf8().toBase64(QByteArray::Base64UrlEncoding
+                                                               | QByteArray::OmitTrailingEquals);
+
+    QUrl url;
+    url.setScheme(QStringLiteral("scala"));
+    url.setHost(QStringLiteral("join"));
+
+    QUrlQuery query;
+    query.addQueryItem(QStringLiteral("id"), calendarId);
+    query.addQueryItem(QStringLiteral("key"), QString::fromLatin1(base64Key));
+    query.addQueryItem(QStringLiteral("name"), cal.name);
+    url.setQuery(query);
+
+    return url.toString();
+}
+
+QString LogosCalendar::parseShareLink(const QString &link) {
+    QUrl url(link);
+    if (!url.isValid() || url.scheme() != QStringLiteral("scala")
+        || url.host() != QStringLiteral("join"))
+        return {};
+
+    QUrlQuery query(url);
+    QString id = query.queryItemValue(QStringLiteral("id"));
+    QString base64Key = query.queryItemValue(QStringLiteral("key"));
+    QString name = query.queryItemValue(QStringLiteral("name"));
+
+    if (id.isEmpty() || base64Key.isEmpty())
+        return {};
+
+    QByteArray key = QByteArray::fromBase64(base64Key.toLatin1(),
+                                            QByteArray::Base64UrlEncoding
+                                            | QByteArray::OmitTrailingEquals);
+
+    QJsonObject result;
+    result[QStringLiteral("id")] = id;
+    result[QStringLiteral("key")] = QString::fromUtf8(key);
+    result[QStringLiteral("name")] = name;
+
+    return QString::fromUtf8(QJsonDocument(result).toJson(QJsonDocument::Compact));
+}
+
+bool LogosCalendar::handleShareLink(const QString &link) {
+    QString parsed = parseShareLink(link);
+    if (parsed.isEmpty())
+        return false;
+
+    QJsonDocument doc = QJsonDocument::fromJson(parsed.toUtf8());
+    QJsonObject obj = doc.object();
+
+    QString id = obj[QStringLiteral("id")].toString();
+    QString key = obj[QStringLiteral("key")].toString();
+    QString name = obj[QStringLiteral("name")].toString();
+
+    if (id.isEmpty() || key.isEmpty())
+        return false;
+
+    // If calendar doesn't exist yet, create with the shared name
+    auto cal = m_store.getCalendar(id);
+    if (cal.id.isEmpty() && !name.isEmpty()) {
+        cal.id = id;
+        cal.name = name;
+        cal.color = QStringLiteral("#9C27B0");
+        cal.isShared = true;
+        cal.encryptionKey = key;
+        qint64 now = QDateTime::currentMSecsSinceEpoch();
+        cal.createdAt = now;
+        cal.updatedAt = now;
+        m_store.saveCalendar(cal);
+    }
+
+    return joinSharedCalendar(id, key);
 }
 
 // ── Incoming sync messages ───────────────────────────────────────────────────

--- a/src/calendar_module.h
+++ b/src/calendar_module.h
@@ -6,6 +6,8 @@
 
 #include <QObject>
 #include <QString>
+#include <QUrl>
+#include <QUrlQuery>
 
 #ifdef LOGOS_CORE_AVAILABLE
 #include <interface.h>
@@ -33,6 +35,11 @@ public:
     virtual bool joinSharedCalendar(const QString &calendarId,
                                     const QString &encryptionKey) = 0;
     virtual QString getSyncStatus(const QString &calendarId) = 0;
+
+    // ── Share link API ──────────────────────────────────────────────────────
+    virtual QString generateShareLink(const QString &calendarId) = 0;
+    virtual QString parseShareLink(const QString &link) = 0;
+    virtual bool handleShareLink(const QString &link) = 0;
 };
 
 #define ILogosCalendar_iid "com.logos.module.ILogosCalendar"
@@ -82,6 +89,11 @@ public:
     Q_INVOKABLE bool joinSharedCalendar(const QString &calendarId,
                                         const QString &encryptionKey) override;
     Q_INVOKABLE QString getSyncStatus(const QString &calendarId) override;
+
+    // ── Share link API ──────────────────────────────────────────────────────
+    Q_INVOKABLE QString generateShareLink(const QString &calendarId) override;
+    Q_INVOKABLE QString parseShareLink(const QString &link) override;
+    Q_INVOKABLE bool handleShareLink(const QString &link) override;
 
 signals:
     void eventResponse(const QString &eventName, const QVariantList &args);

--- a/src/qr_generator.cpp
+++ b/src/qr_generator.cpp
@@ -1,0 +1,43 @@
+#include "qr_generator.h"
+
+#include <QByteArray>
+
+QString QrGenerator::generateQrDataUrl(const QString &text) {
+    if (text.isEmpty())
+        return {};
+
+    // TODO: Replace with actual QR code rendering when a QR library is available.
+    // For now, generate a simple SVG placeholder that shows the link text
+    // in a bordered box with a "QR" label.
+
+    // Escape XML special characters in the text for safe SVG embedding
+    QString escaped = text;
+    escaped.replace(QLatin1Char('&'), QStringLiteral("&amp;"));
+    escaped.replace(QLatin1Char('<'), QStringLiteral("&lt;"));
+    escaped.replace(QLatin1Char('>'), QStringLiteral("&gt;"));
+    escaped.replace(QLatin1Char('"'), QStringLiteral("&quot;"));
+
+    // Truncate display text if too long for the SVG box
+    QString displayText = escaped;
+    if (displayText.length() > 60)
+        displayText = displayText.left(57) + QStringLiteral("...");
+
+    QString svg = QStringLiteral(
+        "<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'>"
+        "<rect x='2' y='2' width='196' height='196' rx='8' fill='white' stroke='#333' stroke-width='2'/>"
+        "<text x='100' y='40' text-anchor='middle' font-size='16' font-weight='bold' fill='#333'>QR Code</text>"
+        "<text x='100' y='60' text-anchor='middle' font-size='10' fill='#999'>(placeholder)</text>"
+        "<rect x='30' y='75' width='140' height='100' rx='4' fill='#f5f5f5' stroke='#ccc' stroke-width='1'/>"
+        "<foreignObject x='35' y='80' width='130' height='90'>"
+        "<p xmlns='http://www.w3.org/1999/xhtml' style='font-size:9px;word-break:break-all;color:#555;margin:0;'>"
+        "%1"
+        "</p>"
+        "</foreignObject>"
+        "</svg>"
+    ).arg(displayText);
+
+    QByteArray svgBytes = svg.toUtf8();
+    QByteArray base64 = svgBytes.toBase64();
+
+    return QStringLiteral("data:image/svg+xml;base64,") + QString::fromLatin1(base64);
+}

--- a/src/qr_generator.h
+++ b/src/qr_generator.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <QString>
+
+/**
+ * QrGenerator — Generates a data: URL with a QR-like representation of text.
+ *
+ * Without an external QR library, this returns a data: URL containing a simple
+ * SVG placeholder that displays the link text. When a real QR library becomes
+ * available, swap the implementation to render an actual QR code as PNG.
+ */
+class QrGenerator {
+public:
+    /// Returns a data: URL (SVG) encoding the given text.
+    /// The SVG shows the text in a bordered box as a placeholder for a real QR code.
+    static QString generateQrDataUrl(const QString &text);
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,3 +47,25 @@ target_link_libraries(test_sync PRIVATE
 )
 
 add_test(NAME test_sync COMMAND test_sync)
+
+# ── Sharing tests ────────────────────────────────────────────────────────────
+
+add_executable(test_sharing
+    test_sharing.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/calendar_module.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/calendar_sync.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/calendar_store.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/qr_generator.cpp
+)
+
+target_include_directories(test_sharing PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+target_link_libraries(test_sharing PRIVATE
+    Qt6::Core
+    Qt6::Test
+)
+
+add_test(NAME test_sharing COMMAND test_sharing)

--- a/tests/test_sharing.cpp
+++ b/tests/test_sharing.cpp
@@ -1,0 +1,126 @@
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTest>
+
+#include "calendar_module.h"
+#include "qr_generator.h"
+
+class TestSharing : public QObject {
+    Q_OBJECT
+
+private slots:
+    void generateAndParseRoundtrip();
+    void parseLinkContainsAllFields();
+    void parseInvalidLinkReturnsEmpty();
+    void parseWrongSchemeReturnsEmpty();
+    void parseMissingIdReturnsEmpty();
+    void parseMissingKeyReturnsEmpty();
+    void handleShareLinkJoinsCalendar();
+    void handleInvalidLinkReturnsFalse();
+    void qrGeneratorReturnsDataUrl();
+    void qrGeneratorEmptyInputReturnsEmpty();
+};
+
+void TestSharing::generateAndParseRoundtrip() {
+    LogosCalendar cal;
+
+    // Create a calendar first
+    QString calId = cal.createCalendar("Test Calendar", "#FF0000");
+    QVERIFY(!calId.isEmpty());
+
+    // Generate a share link
+    QString link = cal.generateShareLink(calId);
+    QVERIFY(!link.isEmpty());
+    QVERIFY(link.startsWith("scala://join"));
+
+    // Parse it back
+    QString parsed = cal.parseShareLink(link);
+    QVERIFY(!parsed.isEmpty());
+
+    QJsonDocument doc = QJsonDocument::fromJson(parsed.toUtf8());
+    QJsonObject obj = doc.object();
+
+    QCOMPARE(obj["id"].toString(), calId);
+    QVERIFY(!obj["key"].toString().isEmpty());
+    QCOMPARE(obj["name"].toString(), QStringLiteral("Test Calendar"));
+}
+
+void TestSharing::parseLinkContainsAllFields() {
+    LogosCalendar cal;
+    QString calId = cal.createCalendar("My Calendar", "#00FF00");
+    QString link = cal.generateShareLink(calId);
+
+    QString parsed = cal.parseShareLink(link);
+    QJsonDocument doc = QJsonDocument::fromJson(parsed.toUtf8());
+    QJsonObject obj = doc.object();
+
+    // All three fields must be present
+    QVERIFY(obj.contains("id"));
+    QVERIFY(obj.contains("key"));
+    QVERIFY(obj.contains("name"));
+
+    QVERIFY(!obj["id"].toString().isEmpty());
+    QVERIFY(!obj["key"].toString().isEmpty());
+    QCOMPARE(obj["name"].toString(), QStringLiteral("My Calendar"));
+}
+
+void TestSharing::parseInvalidLinkReturnsEmpty() {
+    LogosCalendar cal;
+
+    QVERIFY(cal.parseShareLink("").isEmpty());
+    QVERIFY(cal.parseShareLink("not a url").isEmpty());
+    QVERIFY(cal.parseShareLink("https://example.com").isEmpty());
+    QVERIFY(cal.parseShareLink("scala://invalid").isEmpty());
+}
+
+void TestSharing::parseWrongSchemeReturnsEmpty() {
+    LogosCalendar cal;
+    QVERIFY(cal.parseShareLink("https://join?id=abc&key=def&name=test").isEmpty());
+}
+
+void TestSharing::parseMissingIdReturnsEmpty() {
+    LogosCalendar cal;
+    QVERIFY(cal.parseShareLink("scala://join?key=dGVzdA&name=test").isEmpty());
+}
+
+void TestSharing::parseMissingKeyReturnsEmpty() {
+    LogosCalendar cal;
+    QVERIFY(cal.parseShareLink("scala://join?id=abc&name=test").isEmpty());
+}
+
+void TestSharing::handleShareLinkJoinsCalendar() {
+    // Create a calendar on one instance and generate a share link
+    LogosCalendar source;
+    QString calId = source.createCalendar("Shared Cal", "#0000FF");
+    QString link = source.generateShareLink(calId);
+    QVERIFY(!link.isEmpty());
+
+    // Join from another instance
+    LogosCalendar dest;
+    bool joined = dest.handleShareLink(link);
+    QVERIFY(joined);
+
+    // Verify the calendar was created on dest
+    QString calendarsJson = dest.listCalendars();
+    QVERIFY(calendarsJson.contains(calId));
+}
+
+void TestSharing::handleInvalidLinkReturnsFalse() {
+    LogosCalendar cal;
+    QVERIFY(!cal.handleShareLink(""));
+    QVERIFY(!cal.handleShareLink("garbage"));
+    QVERIFY(!cal.handleShareLink("https://example.com"));
+}
+
+void TestSharing::qrGeneratorReturnsDataUrl() {
+    QString url = QrGenerator::generateQrDataUrl("scala://join?id=test&key=abc");
+    QVERIFY(!url.isEmpty());
+    QVERIFY(url.startsWith("data:image/svg+xml;base64,"));
+}
+
+void TestSharing::qrGeneratorEmptyInputReturnsEmpty() {
+    QVERIFY(QrGenerator::generateQrDataUrl("").isEmpty());
+}
+
+QTEST_MAIN(TestSharing)
+#include "test_sharing.moc"


### PR DESCRIPTION
## Summary
- `generateShareLink()` / `parseShareLink()` — `scala://` deep link format with base64url-encoded encryption key
- `handleShareLink()` — one-call parse + join shared calendar flow
- `QrGenerator` — SVG placeholder as `data:` URL (no external QR library, per requirements)
- `ShareDialog.qml` — Share tab (link + copy button + QR placeholder) and Join tab (paste link + join)
- `CalendarSidebar.qml` — per-calendar Share button added to each delegate row
- `test_sharing.cpp` — roundtrip, invalid link parsing, handleShareLink integration, QR generator tests

Implements issue #5.

## Test plan
- [x] `generateShareLink` → `parseShareLink` roundtrip preserves id, key, name
- [x] Invalid/malformed links return empty from `parseShareLink`
- [x] `handleShareLink` joins calendar on a fresh instance
- [x] QR generator returns valid `data:image/svg+xml;base64,` URL
- [x] All existing tests (test_calendar, test_sync) still pass
- [x] Full build succeeds with `-DBUILD_TESTS=ON`

🤖 Generated with [Claude Code](https://claude.com/claude-code)