### PR TITLE
fix: standalone runner QML rendering (black screen on headless)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,15 +100,17 @@ if(BUILD_STANDALONE)
 
     qt_add_executable(scala_standalone standalone/main.cpp)
 
-    qt_add_resources(scala_standalone "qml_resources"
-        PREFIX "/"
-        FILES
+    qt_add_qml_module(scala_standalone
+        URI "ScalaApp"
+        VERSION 1.0
+        QML_FILES
             qml/CalendarView.qml
             qml/CalendarGrid.qml
             qml/CalendarSidebar.qml
             qml/EventModal.qml
             qml/EventDetails.qml
             qml/ShareDialog.qml
+        RESOURCE_PREFIX "/ScalaApp"
     )
 
     target_link_libraries(scala_standalone PRIVATE

--- a/scripts/screenshot.sh
+++ b/scripts/screenshot.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
 set -e
 BUILD_DIR="${1:-build-standalone}"
-mkdir -p "$BUILD_DIR"
-cd "$BUILD_DIR"
+mkdir -p "$BUILD_DIR" && cd "$BUILD_DIR"
 cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_STANDALONE=ON
 make -j4 scala_standalone
 cd ..
-xvfb-run -a -s "-screen 0 1024x768x24" "./$BUILD_DIR/scala_standalone" &
+
+# Kill any existing Xvfb on :20
+kill $(cat /tmp/.xvfb-20.pid 2>/dev/null) 2>/dev/null || true
+Xvfb :20 -screen 0 1024x768x24 &
+echo $! > /tmp/.xvfb-20.pid
+sleep 1
+
+DISPLAY=:20 QT_QUICK_BACKEND=software LIBGL_ALWAYS_SOFTWARE=1 \
+    ./$BUILD_DIR/scala_standalone &
 APP_PID=$!
-sleep 3
-scrot screenshot.png -u || import -window root screenshot.png
+sleep 4
+
+DISPLAY=:20 scrot screenshot.png -u
 kill $APP_PID 2>/dev/null || true
-echo "Screenshot saved to screenshot.png"
+kill $(cat /tmp/.xvfb-20.pid) 2>/dev/null || true
+echo "Screenshot saved: screenshot.png"

--- a/standalone/main.cpp
+++ b/standalone/main.cpp
@@ -1,13 +1,19 @@
 #include <QGuiApplication>
-#include <QQmlApplicationEngine>
-#include <QQmlContext>
+#include <QQuickView>
 
 int main(int argc, char *argv[]) {
     QGuiApplication app(argc, argv);
-    QQmlApplicationEngine engine;
-    engine.addImportPath("qrc:/");
-    const QUrl url(QStringLiteral("qrc:/qml/CalendarView.qml"));
-    engine.load(url);
-    if (engine.rootObjects().isEmpty()) return -1;
+
+    // Software rendering for headless/no-GPU environments
+    qputenv("QT_QUICK_BACKEND", "software");
+    qputenv("LIBGL_ALWAYS_SOFTWARE", "1");
+
+    QQuickView view;
+    view.setResizeMode(QQuickView::SizeRootObjectToView);
+    view.setSource(QUrl(QStringLiteral("qrc:/ScalaApp/ScalaApp/qml/CalendarView.qml")));
+    if (view.status() == QQuickView::Error) return -1;
+    view.resize(800, 600);
+    view.show();
+
     return app.exec();
 }


### PR DESCRIPTION
## Summary
Fixes #13.

- Switch from `qt_add_resources` to `qt_add_qml_module` with proper URI/resource prefix for correct QML import resolution
- Switch from `QQmlApplicationEngine` to `QQuickView` since the root component (`CalendarView.qml`) is an `Item`, not a `Window`
- Set `QT_QUICK_BACKEND=software` and `LIBGL_ALWAYS_SOFTWARE=1` in `main.cpp` for headless/no-GPU environments
- Updated `screenshot.sh` with explicit Xvfb lifecycle management and correct env vars

## Root cause
Two issues caused the black screen:
1. `qt_add_resources` embeds QML files but doesn't register them as a QML module, so Qt couldn't resolve import paths at runtime
2. `QQmlApplicationEngine` expects a `Window`-based root element, but `CalendarView.qml` uses `Item` — so no window was ever created

## Test plan
- [x] Build succeeds with `cmake .. -DBUILD_STANDALONE=ON && make -j4`
- [x] App renders calendar UI under Xvfb with software rendering (verified via screenshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)