### PR TITLE
feat: Logos Core identity — stable sender ID and event ownership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build-*/
 *.o
 *.so
 *.dylib

--- a/qml/CalendarView.qml
+++ b/qml/CalendarView.qml
@@ -73,6 +73,15 @@ Item {
                         font.bold: true
                     }
 
+                    Text {
+                        text: typeof calendarModule !== "undefined" && calendarModule.identity
+                              ? "ID: " + calendarModule.identity.substring(0,8) + "..."
+                              : ""
+                        color: "#ccddee"
+                        font.pixelSize: 11
+                        visible: text !== ""
+                    }
+
                     Item { Layout.fillWidth: true }
 
                     Button {

--- a/src/calendar_module.cpp
+++ b/src/calendar_module.cpp
@@ -9,6 +9,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QMessageAuthenticationCode>
 #include <QUrl>
 #include <QUrlQuery>
 #include <QUuid>
@@ -29,6 +30,38 @@ LogosCalendar::LogosCalendar(QObject *parent)
             this, [this](const QString &calendarId) {
         emit syncStatusChanged(calendarId, QStringLiteral("offline"));
     });
+
+    // Load stored identity or generate stable fallback
+    QString stored = m_store.kvGet(QStringLiteral("identity"));
+    if (!stored.isEmpty()) {
+        m_identity = stored;
+    } else {
+        m_identity = generateStableIdentity();
+        m_store.kvSet(QStringLiteral("identity"), m_identity);
+    }
+}
+
+// ── Identity ─────────────────────────────────────────────────────────────────
+
+QString LogosCalendar::getIdentity() const {
+    return m_identity;
+}
+
+void LogosCalendar::setIdentity(const QString &pubkeyHex) {
+    if (m_identity != pubkeyHex) {
+        m_identity = pubkeyHex;
+        m_store.kvSet(QStringLiteral("identity"), m_identity);
+        emit identityChanged();
+    }
+}
+
+QString LogosCalendar::generateStableIdentity() {
+    QByteArray machineId = QSysInfo::machineUniqueId();
+    if (machineId.isEmpty())
+        machineId = QByteArray("scala-fallback-id");
+    QByteArray hash = QCryptographicHash::hash(
+        machineId, QCryptographicHash::Sha256);
+    return QString::fromLatin1(hash.toHex());
 }
 
 // ── Logos Core lifecycle ─────────────────────────────────────────────────────
@@ -62,7 +95,20 @@ void LogosCalendar::initLogos(LogosAPI *logosAPIInstance) {
         m_sync->setMessagingClient(m_messagingClient);
     }
 
-    qInfo() << "LogosCalendar: initialized. version:" << version();
+    // Get identity from accounts module
+    auto accountsClient = m_logosAPI->getClient("accounts_module");
+    if (accountsClient) {
+        QVariant result = accountsClient->invokeRemoteMethod(
+            "accounts_module", "getActiveAccountPubkey");
+        QString pubkey = result.toString();
+        if (!pubkey.isEmpty()) {
+            m_identity = pubkey;
+            m_store.kvSet(QStringLiteral("identity"), m_identity);
+        }
+    }
+
+    qInfo() << "LogosCalendar: initialized. version:" << version()
+            << "identity:" << m_identity.left(8) + "...";
     emit eventResponse("initialized", QVariantList() << "scala" << "0.1.0");
 }
 #endif
@@ -113,6 +159,7 @@ QString LogosCalendar::createEvent(const QString &calendarId, const QString &eve
     scala::CalendarEvent ev = scala::CalendarEvent::fromJson(obj);
     ev.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
     ev.calendarId = calendarId;
+    ev.creatorId = m_identity;
     qint64 now = QDateTime::currentMSecsSinceEpoch();
     ev.createdAt = now;
     ev.updatedAt = now;
@@ -124,6 +171,7 @@ QString LogosCalendar::createEvent(const QString &calendarId, const QString &eve
         SyncMessage msg;
         msg.type = SyncMessageType::CreateEvent;
         msg.calendarId = calendarId;
+        msg.senderId = m_identity;
         msg.payload = QString::fromUtf8(
             QJsonDocument(ev.toJson()).toJson(QJsonDocument::Compact));
         msg.timestamp = now;
@@ -134,11 +182,22 @@ QString LogosCalendar::createEvent(const QString &calendarId, const QString &eve
     return ev.id;
 }
 
-bool LogosCalendar::updateEvent(const QString &eventJson) {
+QString LogosCalendar::updateEvent(const QString &eventJson) {
     QJsonDocument doc = QJsonDocument::fromJson(eventJson.toUtf8());
     QJsonObject obj = doc.object();
 
     scala::CalendarEvent ev = scala::CalendarEvent::fromJson(obj);
+
+    // Ownership check: only creator can update
+    auto existing = m_store.getEvent(ev.id);
+    if (!existing.id.isEmpty() && !existing.creatorId.isEmpty()
+        && existing.creatorId != m_identity) {
+        QJsonObject err;
+        err["error"] = QStringLiteral("not_authorized");
+        return QString::fromUtf8(QJsonDocument(err).toJson(QJsonDocument::Compact));
+    }
+
+    ev.creatorId = existing.creatorId;
     ev.updatedAt = QDateTime::currentMSecsSinceEpoch();
 
     bool ok = m_store.updateEvent(ev);
@@ -148,32 +207,45 @@ bool LogosCalendar::updateEvent(const QString &eventJson) {
             SyncMessage msg;
             msg.type = SyncMessageType::UpdateEvent;
             msg.calendarId = ev.calendarId;
+            msg.senderId = m_identity;
             msg.payload = QString::fromUtf8(
                 QJsonDocument(ev.toJson()).toJson(QJsonDocument::Compact));
             msg.timestamp = ev.updatedAt;
             m_sync->sendMessage(ev.calendarId, msg);
         }
         emit eventResponse("event_updated", QVariantList() << ev.id);
+        return ev.id;
     }
-    return ok;
+    return {};
 }
 
-bool LogosCalendar::deleteEvent(const QString &id) {
-    // Get event before deleting to know the calendarId
+QString LogosCalendar::deleteEvent(const QString &id) {
+    // Get event before deleting to check ownership and know calendarId
     auto ev = m_store.getEvent(id);
+
+    // Ownership check: only creator can delete
+    if (!ev.id.isEmpty() && !ev.creatorId.isEmpty()
+        && ev.creatorId != m_identity) {
+        QJsonObject err;
+        err["error"] = QStringLiteral("not_authorized");
+        return QString::fromUtf8(QJsonDocument(err).toJson(QJsonDocument::Compact));
+    }
+
     bool ok = m_store.deleteEvent(id);
     if (ok) {
         if (!ev.calendarId.isEmpty() && m_sync->isSyncing(ev.calendarId)) {
             SyncMessage msg;
             msg.type = SyncMessageType::DeleteEvent;
             msg.calendarId = ev.calendarId;
+            msg.senderId = m_identity;
             msg.payload = id;
             msg.timestamp = QDateTime::currentMSecsSinceEpoch();
             m_sync->sendMessage(ev.calendarId, msg);
         }
         emit eventResponse("event_deleted", QVariantList() << id);
+        return id;
     }
-    return ok;
+    return {};
 }
 
 QString LogosCalendar::listEvents(const QString &calendarId) {
@@ -244,6 +316,7 @@ bool LogosCalendar::joinSharedCalendar(const QString &calendarId,
     SyncMessage msg;
     msg.type = SyncMessageType::SyncEvents;
     msg.calendarId = calendarId;
+    msg.senderId = m_identity;
     msg.timestamp = QDateTime::currentMSecsSinceEpoch();
     m_sync->sendMessage(calendarId, msg);
 
@@ -390,6 +463,7 @@ void LogosCalendar::onSyncMessageReceived(const QString &calendarId,
             SyncMessage reply;
             reply.type = SyncMessageType::CreateEvent;
             reply.calendarId = calendarId;
+            reply.senderId = m_identity;
             reply.payload = QString::fromUtf8(
                 QJsonDocument(ev.toJson()).toJson(QJsonDocument::Compact));
             reply.timestamp = QDateTime::currentMSecsSinceEpoch();

--- a/src/calendar_module.h
+++ b/src/calendar_module.h
@@ -4,8 +4,10 @@
 #include "calendar_sync.h"
 #include "types.h"
 
+#include <QCryptographicHash>
 #include <QObject>
 #include <QString>
+#include <QSysInfo>
 #include <QUrl>
 #include <QUrlQuery>
 
@@ -25,8 +27,8 @@ public:
     virtual QString listCalendars() = 0;
     virtual bool deleteCalendar(const QString &id) = 0;
     virtual QString createEvent(const QString &calendarId, const QString &eventJson) = 0;
-    virtual bool updateEvent(const QString &eventJson) = 0;
-    virtual bool deleteEvent(const QString &id) = 0;
+    virtual QString updateEvent(const QString &eventJson) = 0;
+    virtual QString deleteEvent(const QString &id) = 0;
     virtual QString listEvents(const QString &calendarId) = 0;
     virtual QString getEvent(const QString &id) = 0;
 
@@ -60,6 +62,8 @@ class LogosCalendar final : public QObject, public ILogosCalendar {
     Q_INTERFACES(ILogosCalendar)
 #endif
 
+    Q_PROPERTY(QString identity READ getIdentity NOTIFY identityChanged)
+
 public:
     explicit LogosCalendar(QObject *parent = nullptr);
     ~LogosCalendar() override = default;
@@ -74,13 +78,17 @@ public:
     Q_INVOKABLE QString version() const { return QStringLiteral("0.1.0"); }
 #endif
 
+    // ── Identity API ────────────────────────────────────────────────────────
+    Q_INVOKABLE QString getIdentity() const;
+    Q_INVOKABLE void setIdentity(const QString &pubkeyHex);
+
     // ── ILogosCalendar ──────────────────────────────────────────────────────
     Q_INVOKABLE QString createCalendar(const QString &name, const QString &color) override;
     Q_INVOKABLE QString listCalendars() override;
     Q_INVOKABLE bool deleteCalendar(const QString &id) override;
     Q_INVOKABLE QString createEvent(const QString &calendarId, const QString &eventJson) override;
-    Q_INVOKABLE bool updateEvent(const QString &eventJson) override;
-    Q_INVOKABLE bool deleteEvent(const QString &id) override;
+    Q_INVOKABLE QString updateEvent(const QString &eventJson) override;
+    Q_INVOKABLE QString deleteEvent(const QString &id) override;
     Q_INVOKABLE QString listEvents(const QString &calendarId) override;
     Q_INVOKABLE QString getEvent(const QString &id) override;
 
@@ -98,12 +106,15 @@ public:
 signals:
     void eventResponse(const QString &eventName, const QVariantList &args);
     void syncStatusChanged(const QString &calendarId, const QString &status);
+    void identityChanged();
 
 private:
     void onSyncMessageReceived(const QString &calendarId, const SyncMessage &msg);
+    static QString generateStableIdentity();
 
     CalendarStore m_store;
     CalendarSync *m_sync = nullptr;
+    QString m_identity;
 
 #ifdef LOGOS_CORE_AVAILABLE
     LogosAPI *m_logosAPI = nullptr;

--- a/src/calendar_store.h
+++ b/src/calendar_store.h
@@ -47,13 +47,13 @@ public:
     bool updateEvent(const scala::CalendarEvent &ev);
     bool deleteEvent(const QString &id);
 
-private:
-    static constexpr const char *KV_NS = "scala";
-
-    // KV helpers
+    // KV helpers (public for identity storage)
     void kvSet(const QString &key, const QString &value) const;
     QString kvGet(const QString &key) const;
     void kvRemove(const QString &key) const;
+
+private:
+    static constexpr const char *KV_NS = "scala";
 
     // Index helpers
     QStringList getIndex(const QString &indexKey) const;

--- a/src/calendar_sync.cpp
+++ b/src/calendar_sync.cpp
@@ -6,6 +6,7 @@
 
 #include <QDebug>
 #include <QJsonDocument>
+#include <QMessageAuthenticationCode>
 
 // ── SyncMessage helpers ─────────────────────────────────────────────────────
 
@@ -38,6 +39,8 @@ QJsonObject SyncMessage::toJson() const {
     obj[QLatin1String("payload")]    = payload;
     obj[QLatin1String("senderId")]   = senderId;
     obj[QLatin1String("timestamp")]  = timestamp;
+    if (!signature.isEmpty())
+        obj[QLatin1String("signature")] = signature;
     return obj;
 }
 
@@ -48,6 +51,7 @@ SyncMessage SyncMessage::fromJson(const QJsonObject &obj) {
     msg.payload    = obj[QLatin1String("payload")].toString();
     msg.senderId   = obj[QLatin1String("senderId")].toString();
     msg.timestamp  = static_cast<qint64>(obj[QLatin1String("timestamp")].toDouble());
+    msg.signature  = obj[QLatin1String("signature")].toString();
     return msg;
 }
 
@@ -58,6 +62,17 @@ QByteArray SyncMessage::toBytes() const {
 SyncMessage SyncMessage::fromBytes(const QByteArray &data) {
     QJsonDocument doc = QJsonDocument::fromJson(data);
     return fromJson(doc.object());
+}
+
+QString SyncMessage::sign(const QString &payload, const QString &key) {
+    QByteArray mac = QMessageAuthenticationCode::hash(
+        payload.toUtf8(), key.toUtf8(), QCryptographicHash::Sha256);
+    return QString::fromLatin1(mac.toHex());
+}
+
+bool SyncMessage::verify(const QString &payload, const QString &signature,
+                          const QString &key) {
+    return sign(payload, key) == signature;
 }
 
 // ── CalendarSync ────────────────────────────────────────────────────────────

--- a/src/calendar_sync.h
+++ b/src/calendar_sync.h
@@ -31,6 +31,8 @@ struct SyncMessage {
     QString senderId;    // Logos identity pubkey
     qint64 timestamp = 0;
 
+    QString signature;
+
     QJsonObject toJson() const;
     static SyncMessage fromJson(const QJsonObject &obj);
     QByteArray toBytes() const;
@@ -38,6 +40,11 @@ struct SyncMessage {
 
     static QString typeToString(SyncMessageType t);
     static SyncMessageType typeFromString(const QString &s);
+
+    // Sign message with identity key (stub — real crypto in follow-up)
+    // For now: HMAC-SHA256(key, payload) as signature field
+    static QString sign(const QString &payload, const QString &key);
+    static bool verify(const QString &payload, const QString &signature, const QString &key);
 };
 
 // ── CalendarSync ────────────────────────────────────────────────────────────

--- a/src/types.h
+++ b/src/types.h
@@ -20,6 +20,7 @@ struct CalendarEvent {
     QString description;
     QString location;
     QStringList attendees;
+    QString creatorId;
     qint64 createdAt = 0;
     qint64 updatedAt = 0;
 
@@ -37,6 +38,7 @@ struct CalendarEvent {
         for (const auto &a : attendees)
             att.append(a);
         obj["attendees"] = att;
+        obj["creatorId"] = creatorId;
         obj["createdAt"] = createdAt;
         obj["updatedAt"] = updatedAt;
         return obj;
@@ -55,6 +57,7 @@ struct CalendarEvent {
         QJsonArray att = obj["attendees"].toArray();
         for (const auto &a : att)
             ev.attendees.append(a.toString());
+        ev.creatorId = obj["creatorId"].toString();
         ev.createdAt = static_cast<qint64>(obj["createdAt"].toDouble());
         ev.updatedAt = static_cast<qint64>(obj["updatedAt"].toDouble());
         return ev;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,3 +69,24 @@ target_link_libraries(test_sharing PRIVATE
 )
 
 add_test(NAME test_sharing COMMAND test_sharing)
+
+# ── Identity tests ────────────────────────────────────────────────────────────
+
+add_executable(test_identity
+    test_identity.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/calendar_module.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/calendar_sync.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/calendar_store.cpp
+)
+
+target_include_directories(test_identity PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+target_link_libraries(test_identity PRIVATE
+    Qt6::Core
+    Qt6::Test
+)
+
+add_test(NAME test_identity COMMAND test_identity)

--- a/tests/test_identity.cpp
+++ b/tests/test_identity.cpp
@@ -1,0 +1,202 @@
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTest>
+
+#include "calendar_module.h"
+#include "calendar_sync.h"
+
+class TestIdentity : public QObject {
+    Q_OBJECT
+
+private slots:
+    void generateStableIdentityNonEmpty();
+    void generateStableIdentitySameValue();
+    void setGetIdentityRoundtrip();
+    void creatorIdSetOnCreateEvent();
+    void creatorCanDeleteOwnEvent();
+    void nonCreatorDeleteReturnsError();
+    void creatorCanUpdateOwnEvent();
+    void nonCreatorUpdateReturnsError();
+    void signVerifyRoundtrip();
+    void signVerifyBadSignature();
+    void creatorIdInEventJson();
+};
+
+void TestIdentity::generateStableIdentityNonEmpty() {
+    LogosCalendar module;
+    QString identity = module.getIdentity();
+    QVERIFY(!identity.isEmpty());
+    // SHA256 hex is 64 chars
+    QCOMPARE(identity.length(), 64);
+}
+
+void TestIdentity::generateStableIdentitySameValue() {
+    LogosCalendar m1;
+    LogosCalendar m2;
+    // Both should generate the same stable identity on the same machine
+    QCOMPARE(m1.getIdentity(), m2.getIdentity());
+}
+
+void TestIdentity::setGetIdentityRoundtrip() {
+    LogosCalendar module;
+    QString original = module.getIdentity();
+    QVERIFY(!original.isEmpty());
+
+    QString custom = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    module.setIdentity(custom);
+    QCOMPARE(module.getIdentity(), custom);
+
+    // Setting same value again should be a no-op
+    module.setIdentity(custom);
+    QCOMPARE(module.getIdentity(), custom);
+}
+
+void TestIdentity::creatorIdSetOnCreateEvent() {
+    LogosCalendar module;
+    QString calId = module.createCalendar("Test", "#FF0000");
+
+    QString evId = module.createEvent(calId, R"({"title":"Meeting"})");
+    QVERIFY(!evId.isEmpty());
+
+    QString evJson = module.getEvent(evId);
+    QJsonDocument doc = QJsonDocument::fromJson(evJson.toUtf8());
+    QJsonObject obj = doc.object();
+
+    QCOMPARE(obj["creatorId"].toString(), module.getIdentity());
+}
+
+void TestIdentity::creatorCanDeleteOwnEvent() {
+    LogosCalendar module;
+    QString calId = module.createCalendar("Test", "#FF0000");
+
+    QString evId = module.createEvent(calId, R"({"title":"My Event"})");
+    QVERIFY(!evId.isEmpty());
+
+    // Creator deletes own event — should succeed
+    QString result = module.deleteEvent(evId);
+    QCOMPARE(result, evId);
+
+    // Event should be gone
+    QString gone = module.getEvent(evId);
+    QVERIFY(gone.isEmpty());
+}
+
+void TestIdentity::nonCreatorDeleteReturnsError() {
+    LogosCalendar creator;
+    QString calId = creator.createCalendar("Test", "#FF0000");
+
+    QString evId = creator.createEvent(calId, R"({"title":"Protected Event"})");
+    QVERIFY(!evId.isEmpty());
+
+    // Different identity tries to delete
+    LogosCalendar other;
+    other.setIdentity("aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666000011112222abcd");
+
+    // Need to make the event visible to the other module — copy it
+    // In real use, sync would handle this; for testing, we re-create the store scenario
+    // The other module has a separate store, so we create the event there too
+    QString evJson = creator.getEvent(evId);
+    QJsonDocument doc = QJsonDocument::fromJson(evJson.toUtf8());
+    QJsonObject obj = doc.object();
+    // Create a calendar with same id in other module's store
+    other.createCalendar("Test", "#FF0000");
+    // Save the event directly by creating it with the same creatorId
+    // We'll test ownership by having the other module try to delete from creator's store
+    // Actually, since each LogosCalendar has its own store, we test with the same instance
+    // by changing identity
+    LogosCalendar module;
+    QString calId2 = module.createCalendar("Test", "#FF0000");
+    QString evId2 = module.createEvent(calId2, R"({"title":"Protected"})");
+    QVERIFY(!evId2.isEmpty());
+
+    // Change identity to simulate a different user
+    module.setIdentity("aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666000011112222abcd");
+
+    // Try to delete — should fail with not_authorized
+    QString result = module.deleteEvent(evId2);
+    QVERIFY(!result.isEmpty());
+    QJsonDocument resDoc = QJsonDocument::fromJson(result.toUtf8());
+    QCOMPARE(resDoc.object()["error"].toString(), QStringLiteral("not_authorized"));
+
+    // Event should still exist
+    // Switch identity back to verify
+    module.setIdentity(module.getIdentity()); // identity is already changed
+    // The event should still be in the store
+    QString stillThere = module.getEvent(evId2);
+    QVERIFY(!stillThere.isEmpty());
+}
+
+void TestIdentity::creatorCanUpdateOwnEvent() {
+    LogosCalendar module;
+    QString calId = module.createCalendar("Test", "#FF0000");
+    QString evId = module.createEvent(calId, R"({"title":"Original"})");
+
+    // Build update JSON with required fields
+    QJsonObject updateObj;
+    updateObj["id"] = evId;
+    updateObj["calendarId"] = calId;
+    updateObj["title"] = "Updated";
+    QString updateJson = QString::fromUtf8(
+        QJsonDocument(updateObj).toJson(QJsonDocument::Compact));
+
+    QString result = module.updateEvent(updateJson);
+    QCOMPARE(result, evId);
+}
+
+void TestIdentity::nonCreatorUpdateReturnsError() {
+    LogosCalendar module;
+    QString calId = module.createCalendar("Test", "#FF0000");
+    QString evId = module.createEvent(calId, R"({"title":"Original"})");
+    QString originalIdentity = module.getIdentity();
+
+    // Switch to different identity
+    module.setIdentity("bbbb2222cccc3333dddd4444eeee5555ffff6666000011112222333344445555");
+
+    QJsonObject updateObj;
+    updateObj["id"] = evId;
+    updateObj["calendarId"] = calId;
+    updateObj["title"] = "Hacked";
+    QString updateJson = QString::fromUtf8(
+        QJsonDocument(updateObj).toJson(QJsonDocument::Compact));
+
+    QString result = module.updateEvent(updateJson);
+    QVERIFY(!result.isEmpty());
+    QJsonDocument doc = QJsonDocument::fromJson(result.toUtf8());
+    QCOMPARE(doc.object()["error"].toString(), QStringLiteral("not_authorized"));
+}
+
+void TestIdentity::signVerifyRoundtrip() {
+    QString payload = "test payload data";
+    QString key = "encryption-key-123";
+
+    QString sig = SyncMessage::sign(payload, key);
+    QVERIFY(!sig.isEmpty());
+    QVERIFY(SyncMessage::verify(payload, sig, key));
+}
+
+void TestIdentity::signVerifyBadSignature() {
+    QString payload = "test payload data";
+    QString key = "encryption-key-123";
+
+    QVERIFY(!SyncMessage::verify(payload, "bad-signature", key));
+    QVERIFY(!SyncMessage::verify(payload, SyncMessage::sign(payload, key), "wrong-key"));
+}
+
+void TestIdentity::creatorIdInEventJson() {
+    scala::CalendarEvent ev;
+    ev.id = "evt-001";
+    ev.calendarId = "cal-001";
+    ev.title = "Test";
+    ev.creatorId = "abcdef1234567890";
+    ev.createdAt = 1700000000000LL;
+    ev.updatedAt = 1700000000000LL;
+
+    QJsonObject json = ev.toJson();
+    QCOMPARE(json["creatorId"].toString(), QStringLiteral("abcdef1234567890"));
+
+    scala::CalendarEvent restored = scala::CalendarEvent::fromJson(json);
+    QCOMPARE(restored.creatorId, ev.creatorId);
+}
+
+QTEST_MAIN(TestIdentity)
+#include "test_identity.moc"


### PR DESCRIPTION
## Summary
Implements issue #7.

- `getIdentity()` / `setIdentity()` — Logos accounts module via QtRO, stable fallback via QSysInfo
- Stable machine identity stored in KV (`scala:identity`)
- `senderId` in all events/sync messages is now identity pubkey
- Event ownership: only creator can UPDATE/DELETE (returns `{"error":"not_authorized"}`)
- Message signing stub (HMAC-SHA256 `sign()`/`verify()`)
- QML identity indicator in header
- Tests for identity stability and ownership checks

## Test plan
- [x] `generateStableIdentity()` returns non-empty 64-char hex, same value on second call
- [x] `setIdentity` / `getIdentity` roundtrip
- [x] `creatorId` set on `createEvent()`
- [x] Creator can delete/update their own events
- [x] Non-creator delete/update returns `{"error":"not_authorized"}`
- [x] HMAC-SHA256 `sign()`/`verify()` roundtrip
- [x] `creatorId` persists through JSON serialization
- [x] All 4 test suites pass (51 tests total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)