### PR TITLE
feat: Nix build and logos-module-builder packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Qt6
+        run: sudo apt-get install -y qt6-base-dev qt6-declarative-dev
+      - name: Build plugin
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Release
+          cmake --build build -j4
+      - name: Run tests
+        run: cd build && ctest -V
+      - name: Build standalone
+        run: |
+          cmake -B build-standalone -DBUILD_STANDALONE=ON
+          cmake --build build-standalone -j4 --target scala_standalone

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,27 @@
   };
 
   outputs = { self, logos-module-builder, nixpkgs, ... }:
-    logos-module-builder.lib.mkLogosModule {
-      src = ./.;
-      configFile = ./module.yaml;
+    let
+      moduleOutputs = logos-module-builder.lib.mkLogosModule {
+        src = ./.;
+        configFile = ./module.yaml;
+      };
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+      });
+    in
+    moduleOutputs // {
+      packages = forAllSystems ({ pkgs }:
+        let
+          base = moduleOutputs.packages.${pkgs.system} or {};
+        in
+        base // {
+          ui = pkgs.runCommand "scala-ui" {} ''
+            mkdir -p $out/qml
+            cp -r ${./qml}/* $out/qml/
+          '';
+        }
+      );
     };
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "scala",
+  "version": "0.1.0",
+  "description": "Privacy-first shared calendar app built on Logos Core",
+  "main": {
+    "linux-x86_64": "scala_plugin.so",
+    "linux-aarch64": "scala_plugin.so",
+    "darwin-arm64": "scala_plugin.so",
+    "darwin-x86_64": "scala_plugin.so"
+  },
+  "dependencies": ["kv_module", "messaging_module", "accounts_module"]
+}

--- a/metadata.json
+++ b/metadata.json
@@ -14,6 +14,6 @@
     "darwin-arm64": "scala_plugin.dylib",
     "windows-x86_64": "scala_plugin.dll"
   },
-  "dependencies": ["kv_module", "messaging_module"],
+  "dependencies": ["kv_module", "messaging_module", "accounts_module"],
   "capabilities": []
 }

--- a/module.yaml
+++ b/module.yaml
@@ -1,11 +1,24 @@
 name: scala
+display_name: Scala Calendar
 version: 0.1.0
-type: core
-category: general
-description: "Secure Calendar App — privacy-first shared calendar module for Logos Core"
+description: Privacy-first shared calendar app built on Logos Core
+author: jimmy-claw
+license: MIT
+entry_point: scala_plugin.so
+qt_version: "6"
 
 dependencies:
   - kv_module
+  - messaging_module
+  - accounts_module
+
+qml_files:
+  - qml/CalendarView.qml
+  - qml/CalendarGrid.qml
+  - qml/CalendarSidebar.qml
+  - qml/EventModal.qml
+  - qml/EventDetails.qml
+  - qml/ShareDialog.qml
 
 nix_packages:
   build: []


### PR DESCRIPTION
## Summary
Implements issue #8.

- `module.yaml` for logos-module-builder (full schema: deps, QML files, entry point, Qt version)
- `flake.nix` with `.#module` and `.#ui` targets (mirrors logos-kv-module pattern)
- `manifest.json` (platform-keyed runtime manifest)
- CI workflow: build + test + standalone on every push/PR
- Updated `metadata.json` with `accounts_module` dependency

Scala is now packageable as a `.lgx` installable via `lgpm`.

## Test plan
- [ ] `nix build .#module` produces `scala_plugin.so`
- [ ] `nix build .#ui` packages QML files
- [ ] CI workflow runs on push to main / PR
- [ ] `cmake -B build && cmake --build build` still works locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)