### PR TITLE
fix: wire QML UI to C++ CalendarModule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,15 @@ if(BUILD_STANDALONE)
 
     qt_add_executable(scala_standalone standalone/main.cpp)
 
+    target_sources(scala_standalone PRIVATE
+        src/calendar_module.cpp
+        src/calendar_store.cpp
+        src/calendar_sync.cpp
+        src/qr_generator.cpp
+    )
+
+    target_include_directories(scala_standalone PRIVATE src)
+
     qt_add_qml_module(scala_standalone
         URI "ScalaApp"
         VERSION 1.0

--- a/qml/CalendarView.qml
+++ b/qml/CalendarView.qml
@@ -17,17 +17,89 @@ Item {
     // ── State ──────────────────────────────────────────────────────────────
     property var selectedEvent: null
     property bool showEventDetails: false
+    property var calendarList: []
+    property var allEvents: []
+    property string selectedCalendarId: ""
 
-    // ── Mock events for demo ───────────────────────────────────────────────
-    property var mockEvents: [
-        { day: 5,  color: "#4CAF50" },
-        { day: 5,  color: "#2196F3" },
-        { day: 12, color: "#4CAF50" },
-        { day: 18, color: "#FF9800" },
-        { day: 22, color: "#2196F3" },
-        { day: 22, color: "#FF9800" },
-        { day: 28, color: "#4CAF50" }
+    // ── Preset colors for new calendar dialog ──────────────────────────────
+    property var presetColors: [
+        "#4CAF50", "#2196F3", "#FF9800", "#9C27B0",
+        "#F44336", "#00BCD4", "#795548", "#607D8B"
     ]
+
+    // ── Data helpers ───────────────────────────────────────────────────────
+    function refreshCalendars() {
+        var result = calendarModule.listCalendars()
+        calendarList = JSON.parse(result || "[]")
+        updateSidebarModel()
+    }
+
+    function refreshEvents() {
+        allEvents = []
+        for (var i = 0; i < calendarList.length; i++) {
+            var evts = JSON.parse(calendarModule.listEvents(calendarList[i].id) || "[]")
+            allEvents = allEvents.concat(evts)
+        }
+    }
+
+    function updateSidebarModel() {
+        sidebarCalendarModel.clear()
+        for (var i = 0; i < calendarList.length; i++) {
+            var c = calendarList[i]
+            sidebarCalendarModel.append({
+                calId: c.id,
+                calName: c.name,
+                calColor: c.color,
+                calVisible: true
+            })
+        }
+    }
+
+    function findCalendar(calId) {
+        for (var i = 0; i < calendarList.length; i++) {
+            if (calendarList[i].id === calId) return calendarList[i]
+        }
+        return null
+    }
+
+    function eventsForGrid() {
+        var dots = []
+        var month = calendarGrid.displayMonth
+        var year = calendarGrid.displayYear
+        for (var i = 0; i < allEvents.length; i++) {
+            var ev = allEvents[i]
+            var d = new Date(ev.startTime)
+            if (d.getMonth() === month && d.getFullYear() === year) {
+                var cal = findCalendar(ev.calendarId)
+                dots.push({ day: d.getDate(), color: cal ? cal.color : "#2196F3" })
+            }
+        }
+        return dots
+    }
+
+    function msFromDateTime(dateStr, timeStr, fallbackNow) {
+        if (!dateStr || dateStr === "") {
+            return fallbackNow ? Date.now() : 0
+        }
+        var parts = dateStr.split("-")
+        var y = parseInt(parts[0]), m = parseInt(parts[1]) - 1, day = parseInt(parts[2])
+        var h = 0, min = 0
+        if (timeStr && timeStr !== "") {
+            var tp = timeStr.split(":")
+            h = parseInt(tp[0])
+            min = parseInt(tp[1])
+        }
+        return new Date(y, m, day, h, min).getTime()
+    }
+
+    // ── Sidebar calendar model ─────────────────────────────────────────────
+    ListModel { id: sidebarCalendarModel }
+
+    // ── Load data on startup ───────────────────────────────────────────────
+    Component.onCompleted: {
+        refreshCalendars()
+        refreshEvents()
+    }
 
     RowLayout {
         anchors.fill: parent
@@ -37,15 +109,23 @@ Item {
         CalendarSidebar {
             Layout.preferredWidth: 220
             Layout.fillHeight: true
+            calendarModel: sidebarCalendarModel
 
             onCalendarToggled: function(calId, vis) {
                 console.log("Calendar toggled:", calId, vis);
             }
             onNewCalendarRequested: {
-                console.log("New calendar requested");
+                newCalendarDialog.open()
             }
             onCalendarSelected: function(calId) {
+                selectedCalendarId = calId
                 console.log("Calendar selected:", calId);
+            }
+            onShareRequested: function(calId, calName) {
+                var link = calendarModule.generateShareLink(calId)
+                shareDialog.shareLink = link
+                shareDialog.calendarName = calName
+                shareDialog.open()
             }
         }
 
@@ -88,6 +168,7 @@ Item {
                         text: "+ New Event"
                         onClicked: {
                             eventModal.clear();
+                            eventModal.calendars = calendarList;
                             eventModal.open();
                         }
                         background: Rectangle {
@@ -118,28 +199,48 @@ Item {
 
                 // Calendar grid
                 CalendarGrid {
+                    id: calendarGrid
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    events: mockEvents
+                    events: eventsForGrid()
+
+                    onNavigated: {
+                        // Re-evaluate events binding when month changes
+                        events = eventsForGrid()
+                    }
 
                     onDayClicked: function(day, month, year) {
                         console.log("Day clicked:", day, month + 1, year);
 
-                        // Demo: show event details for days with events
-                        var dayEvents = eventsForDay(day);
+                        var dayEvents = []
+                        for (var i = 0; i < allEvents.length; i++) {
+                            var ev = allEvents[i]
+                            var d = new Date(ev.startTime)
+                            if (d.getDate() === day && d.getMonth() === month && d.getFullYear() === year) {
+                                dayEvents.push(ev)
+                            }
+                        }
+
                         if (dayEvents.length > 0) {
+                            var first = dayEvents[0]
+                            var startDt = new Date(first.startTime)
+                            var endDt = new Date(first.endTime)
+                            var cal = findCalendar(first.calendarId)
+
+                            var pad = function(n) { return n < 10 ? "0" + n : "" + n }
+
                             eventDetails.loadEvent({
-                                id: "evt-" + day,
-                                title: "Sample Event on " + day,
-                                description: "This is a sample event.",
-                                location: "Conference Room A",
-                                startDate: year + "-" + (month+1) + "-" + day,
-                                startTime: "09:00",
-                                endDate: year + "-" + (month+1) + "-" + day,
-                                endTime: "10:00",
-                                allDay: false,
-                                calendarName: "Personal",
-                                calendarColor: dayEvents[0].color
+                                id: first.id,
+                                title: first.title,
+                                description: first.description || "",
+                                location: first.location || "",
+                                startDate: startDt.getFullYear() + "-" + pad(startDt.getMonth()+1) + "-" + pad(startDt.getDate()),
+                                startTime: pad(startDt.getHours()) + ":" + pad(startDt.getMinutes()),
+                                endDate: endDt.getFullYear() + "-" + pad(endDt.getMonth()+1) + "-" + pad(endDt.getDate()),
+                                endTime: pad(endDt.getHours()) + ":" + pad(endDt.getMinutes()),
+                                allDay: first.allDay || false,
+                                calendarName: cal ? cal.name : "",
+                                calendarColor: cal ? cal.color : "#2196F3"
                             });
                             showEventDetails = true;
                         } else {
@@ -162,23 +263,32 @@ Item {
                     }
 
                     onEditRequested: function(evId) {
+                        var evJson = calendarModule.getEvent(evId)
+                        var ev = JSON.parse(evJson || "{}")
+                        var startDt = new Date(ev.startTime)
+                        var endDt = new Date(ev.endTime)
+                        var pad = function(n) { return n < 10 ? "0" + n : "" + n }
+
                         eventModal.loadEvent({
-                            id: evId,
-                            title: eventDetails.eventTitle,
-                            description: eventDetails.eventDescription,
-                            location: eventDetails.eventLocation,
-                            startDate: eventDetails.eventStartDate,
-                            startTime: eventDetails.eventStartTime,
-                            endDate: eventDetails.eventEndDate,
-                            endTime: eventDetails.eventEndTime,
-                            allDay: eventDetails.eventAllDay,
-                            calendarId: ""
+                            id: ev.id,
+                            title: ev.title,
+                            description: ev.description || "",
+                            location: ev.location || "",
+                            startDate: startDt.getFullYear() + "-" + pad(startDt.getMonth()+1) + "-" + pad(startDt.getDate()),
+                            startTime: pad(startDt.getHours()) + ":" + pad(startDt.getMinutes()),
+                            endDate: endDt.getFullYear() + "-" + pad(endDt.getMonth()+1) + "-" + pad(endDt.getDate()),
+                            endTime: pad(endDt.getHours()) + ":" + pad(endDt.getMinutes()),
+                            allDay: ev.allDay || false,
+                            calendarId: ev.calendarId || ""
                         });
+                        eventModal.calendars = calendarList;
                         eventModal.open();
                     }
 
                     onDeleteConfirmed: function(evId) {
-                        console.log("Delete event:", evId);
+                        calendarModule.deleteEvent(evId)
+                        refreshEvents()
+                        calendarGrid.events = eventsForGrid()
                         showEventDetails = false;
                         eventDetails.eventId = "";
                     }
@@ -197,11 +307,143 @@ Item {
         id: eventModal
 
         onSaveClicked: function(eventData) {
-            console.log("Event saved:", JSON.stringify(eventData));
+            var evJson = {
+                title: eventData.title,
+                description: eventData.description,
+                location: eventData.location,
+                startTime: msFromDateTime(eventData.startDate, eventData.startTime, true),
+                endTime: msFromDateTime(eventData.endDate, eventData.endTime, true),
+                allDay: eventData.allDay
+            }
+
+            if (eventData.id && eventData.id !== "") {
+                evJson.id = eventData.id
+                evJson.calendarId = eventData.calendarId
+                calendarModule.updateEvent(JSON.stringify(evJson))
+            } else {
+                var calId = eventData.calendarId || selectedCalendarId
+                    || (calendarList.length > 0 ? calendarList[0].id : "")
+                evJson.calendarId = calId
+                calendarModule.createEvent(calId, JSON.stringify(evJson))
+            }
+            refreshEvents()
+            calendarGrid.events = eventsForGrid()
         }
 
         onCancelClicked: {
             console.log("Event creation cancelled");
+        }
+    }
+
+    // ── New Calendar dialog ────────────────────────────────────────────────
+    Popup {
+        id: newCalendarDialog
+        modal: true
+        focus: true
+        anchors.centerIn: parent
+        width: 340
+        height: 280
+        padding: 20
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+        property string selectedColor: presetColors[0]
+
+        background: Rectangle { radius: 12; color: "white"; border.color: "#e0e0e0" }
+
+        onOpened: {
+            newCalNameField.text = ""
+            selectedColor = presetColors[0]
+            newCalNameField.forceActiveFocus()
+        }
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 12
+
+            Text { text: "New Calendar"; font.pixelSize: 18; font.bold: true; color: "#212121" }
+            Rectangle { Layout.fillWidth: true; height: 1; color: "#e0e0e0" }
+
+            Text { text: "Name"; font.pixelSize: 13; color: "#555" }
+            TextField {
+                id: newCalNameField
+                Layout.fillWidth: true
+                placeholderText: "Calendar name"
+                font.pixelSize: 14
+                background: Rectangle { radius: 4; color: "#f5f5f5"; border.color: "#e0e0e0" }
+            }
+
+            Text { text: "Color"; font.pixelSize: 13; color: "#555" }
+            Row {
+                spacing: 8
+                Repeater {
+                    model: presetColors
+                    delegate: Rectangle {
+                        width: 28; height: 28; radius: 14
+                        color: modelData
+                        border.width: newCalendarDialog.selectedColor === modelData ? 3 : 0
+                        border.color: "#333"
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: newCalendarDialog.selectedColor = modelData
+                        }
+                    }
+                }
+            }
+
+            Item { Layout.fillHeight: true }
+
+            RowLayout {
+                spacing: 8
+                Item { Layout.fillWidth: true }
+                Button {
+                    text: "Cancel"
+                    onClicked: newCalendarDialog.close()
+                    background: Rectangle { radius: 6; color: parent.hovered ? "#eee" : "#f5f5f5" }
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 14; color: "#555"
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                }
+                Button {
+                    text: "Create"
+                    enabled: newCalNameField.text.trim().length > 0
+                    onClicked: {
+                        calendarModule.createCalendar(newCalNameField.text.trim(),
+                                                      newCalendarDialog.selectedColor)
+                        refreshCalendars()
+                        refreshEvents()
+                        calendarGrid.events = eventsForGrid()
+                        newCalendarDialog.close()
+                    }
+                    background: Rectangle {
+                        radius: 6
+                        color: parent.enabled
+                            ? (parent.hovered ? Qt.lighter("#4CAF50", 1.1) : "#4CAF50")
+                            : "#ccc"
+                    }
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 14; font.bold: true; color: "white"
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Share dialog ───────────────────────────────────────────────────────
+    ShareDialog {
+        id: shareDialog
+
+        onJoinRequested: function(link) {
+            var ok = calendarModule.handleShareLink(link)
+            if (ok) {
+                refreshCalendars()
+                refreshEvents()
+                calendarGrid.events = eventsForGrid()
+                shareDialog.close()
+            }
         }
     }
 }

--- a/qml/EventModal.qml
+++ b/qml/EventModal.qml
@@ -33,6 +33,7 @@ Popup {
     property string endTime: ""
     property string calendarId: ""
     property string eventId: ""
+    property var calendars: []
 
     signal saveClicked(var eventData)
     signal cancelClicked()
@@ -48,6 +49,8 @@ Popup {
         allDaySwitch.checked = false;
         mode = "create";
         eventId = "";
+        calendarId = "";
+        calendarCombo.currentIndex = 0;
     }
 
     function loadEvent(ev) {
@@ -62,6 +65,13 @@ Popup {
         endTimeField.text = ev.endTime || "";
         allDaySwitch.checked = ev.allDay || false;
         calendarId = ev.calendarId || "";
+        // Select the matching calendar in the combo
+        for (var i = 0; i < calendars.length; i++) {
+            if (calendars[i].id === calendarId) {
+                calendarCombo.currentIndex = i;
+                break;
+            }
+        }
     }
 
     background: Rectangle {
@@ -141,6 +151,41 @@ Popup {
                 anchors.rightMargin: 16
                 anchors.top: parent.top
                 anchors.topMargin: 12
+
+                // Calendar selector
+                Text {
+                    text: "Calendar"
+                    font.pixelSize: 13
+                    color: "#555"
+                    visible: calendars.length > 0
+                }
+                ComboBox {
+                    id: calendarCombo
+                    Layout.fillWidth: true
+                    visible: calendars.length > 0
+                    model: calendars
+                    textRole: "name"
+                    onCurrentIndexChanged: {
+                        if (currentIndex >= 0 && currentIndex < calendars.length) {
+                            calendarId = calendars[currentIndex].id
+                        }
+                    }
+                    delegate: ItemDelegate {
+                        width: calendarCombo.width
+                        contentItem: RowLayout {
+                            spacing: 8
+                            Rectangle {
+                                width: 10; height: 10; radius: 5
+                                color: modelData.color || "#2196F3"
+                            }
+                            Text {
+                                text: modelData.name || ""
+                                font.pixelSize: 13
+                                Layout.fillWidth: true
+                            }
+                        }
+                    }
+                }
 
                 // Title
                 Text { text: "Title *"; font.pixelSize: 13; color: "#555" }

--- a/standalone/main.cpp
+++ b/standalone/main.cpp
@@ -1,5 +1,8 @@
 #include <QGuiApplication>
+#include <QQmlContext>
 #include <QQuickView>
+
+#include "calendar_module.h"
 
 int main(int argc, char *argv[]) {
     QGuiApplication app(argc, argv);
@@ -8,7 +11,10 @@ int main(int argc, char *argv[]) {
     qputenv("QT_QUICK_BACKEND", "software");
     qputenv("LIBGL_ALWAYS_SOFTWARE", "1");
 
+    LogosCalendar module;
+
     QQuickView view;
+    view.rootContext()->setContextProperty("calendarModule", &module);
     view.setResizeMode(QQuickView::SizeRootObjectToView);
     view.setSource(QUrl(QStringLiteral("qrc:/ScalaApp/ScalaApp/qml/CalendarView.qml")));
     if (view.status() == QQuickView::Error) return -1;


### PR DESCRIPTION
## Summary
Closes #19, #20, #21, #22, #27.

- **CalendarModule exposed as QML context property** in `standalone/main.cpp`, with module sources added to the standalone CMake target
- **Calendars and events loaded from C++ module on startup** — mock data removed, replaced with real `CalendarStore` data via `Component.onCompleted`
- **New Calendar dialog** with name field + preset color picker, wired to `createCalendar()`
- **EventModal save** wired to `createEvent()`/`updateEvent()` with date string → millisecond conversion
- **Calendar selector ComboBox** added to EventModal showing calendar names with color dots
- **Share button** wired to `generateShareLink()` + `ShareDialog` join flow via `handleShareLink()`
- **Event delete** wired to `deleteEvent()` from the EventDetails panel

## Test plan
- [ ] Build with `cmake .. -DBUILD_STANDALONE=ON && make`
- [ ] Run standalone — verify calendars load on startup (no mock data)
- [ ] Create a new calendar via sidebar button — verify it appears in sidebar
- [ ] Create a new event via "+ New Event" — verify calendar selector shows available calendars
- [ ] Edit an existing event — verify data loads correctly in modal
- [ ] Delete an event — verify it disappears from grid
- [ ] Share a calendar — verify share link is generated and shown in dialog
- [ ] Join via share link — verify calendar is added

🤖 Generated with [Claude Code](https://claude.com/claude-code)