### PR TITLE
feat: SCALA_NAMESPACE env var for multi-instance testing

### DIFF
--- a/src/calendar_module.cpp
+++ b/src/calendar_module.cpp
@@ -41,6 +41,12 @@ LogosCalendar::LogosCalendar(QObject *parent)
     }
 }
 
+// ── Namespace ────────────────────────────────────────────────────────────────
+
+void LogosCalendar::setNamespace(const QString &ns) {
+    m_store.setNamespace(ns);
+}
+
 // ── Identity ─────────────────────────────────────────────────────────────────
 
 QString LogosCalendar::getIdentity() const {

--- a/src/calendar_module.h
+++ b/src/calendar_module.h
@@ -78,6 +78,9 @@ public:
     Q_INVOKABLE QString version() const { return QStringLiteral("0.1.0"); }
 #endif
 
+    // ── Namespace API ─────────────────────────────────────────────────────
+    Q_INVOKABLE void setNamespace(const QString &ns);
+
     // ── Identity API ────────────────────────────────────────────────────────
     Q_INVOKABLE QString getIdentity() const;
     Q_INVOKABLE void setIdentity(const QString &pubkeyHex);

--- a/src/calendar_store.cpp
+++ b/src/calendar_store.cpp
@@ -17,40 +17,53 @@ void CalendarStore::setClient(LogosAPIClient *client) {
 }
 #endif
 
+// ── Namespace ────────────────────────────────────────────────────────────────
+
+void CalendarStore::setNamespace(const QString &ns) {
+    m_namespace = ns.isEmpty() ? QStringLiteral("default") : ns;
+}
+
+QString CalendarStore::namespacedKey(const QString &key) const {
+    return QStringLiteral("scala:") + m_namespace + QStringLiteral(":") + key;
+}
+
 // ── KV helpers ───────────────────────────────────────────────────────────────
 
 void CalendarStore::kvSet(const QString &key, const QString &value) const {
+    const QString nsKey = namespacedKey(key);
 #ifdef LOGOS_CORE_AVAILABLE
     if (m_kvClient) {
         m_kvClient->invokeRemoteMethod("kv_module", "set",
-                                       QString(KV_NS), key, value);
+                                       QString(KV_NS), nsKey, value);
     }
 #else
-    m_mem[key] = value;
+    m_mem[nsKey] = value;
 #endif
 }
 
 QString CalendarStore::kvGet(const QString &key) const {
+    const QString nsKey = namespacedKey(key);
 #ifdef LOGOS_CORE_AVAILABLE
     if (m_kvClient) {
         QVariant result = m_kvClient->invokeRemoteMethod("kv_module", "get",
-                                                         QString(KV_NS), key);
+                                                         QString(KV_NS), nsKey);
         return result.toString();
     }
     return {};
 #else
-    return m_mem.value(key);
+    return m_mem.value(nsKey);
 #endif
 }
 
 void CalendarStore::kvRemove(const QString &key) const {
+    const QString nsKey = namespacedKey(key);
 #ifdef LOGOS_CORE_AVAILABLE
     if (m_kvClient) {
         m_kvClient->invokeRemoteMethod("kv_module", "remove",
-                                       QString(KV_NS), key);
+                                       QString(KV_NS), nsKey);
     }
 #else
-    m_mem.remove(key);
+    m_mem.remove(nsKey);
 #endif
 }
 

--- a/src/calendar_store.h
+++ b/src/calendar_store.h
@@ -52,8 +52,13 @@ public:
     QString kvGet(const QString &key) const;
     void kvRemove(const QString &key) const;
 
+    // Namespace support for multi-instance testing
+    void setNamespace(const QString &ns);
+    QString namespacedKey(const QString &key) const;
+
 private:
     static constexpr const char *KV_NS = "scala";
+    QString m_namespace = QStringLiteral("default");
 
     // Index helpers
     QStringList getIndex(const QString &indexKey) const;

--- a/standalone/main.cpp
+++ b/standalone/main.cpp
@@ -12,6 +12,7 @@ int main(int argc, char *argv[]) {
     qputenv("LIBGL_ALWAYS_SOFTWARE", "1");
 
     LogosCalendar module;
+    module.setNamespace(qEnvironmentVariable("SCALA_NAMESPACE", "default"));
 
     QQuickView view;
     view.rootContext()->setContextProperty("calendarModule", &module);


### PR DESCRIPTION
## Summary
- Adds namespace support to `CalendarStore` via `setNamespace()` / `namespacedKey()` methods
- All KV keys are now prefixed with `scala:<namespace>:` for isolation between instances
- `standalone/main.cpp` reads `SCALA_NAMESPACE` env var (defaults to `"default"`)

```bash
SCALA_NAMESPACE=alice ./scala_standalone  # uses scala:alice:* keys
SCALA_NAMESPACE=bob ./scala_standalone    # uses scala:bob:* keys
```

Closes #33

## Test plan
- [ ] Build standalone: `cmake --build build-ns --target scala_standalone`
- [ ] Run two instances with different SCALA_NAMESPACE values
- [ ] Verify each instance has independent calendar/event data
- [ ] Verify default namespace still works when env var is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)