### PR TITLE
test: wiring regression + namespace isolation tests + CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Qt6
-        run: sudo apt-get install -y qt6-base-dev qt6-declarative-dev
+        run: sudo apt-get install -y qt6-base-dev qt6-declarative-dev qt6-remoteobjects-dev xvfb
       - name: Build plugin
         run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=Release
+          cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON
           cmake --build build -j4
       - name: Run tests
-        run: cd build && ctest -V
+        run: cd build && ctest -V --output-junit test-results.xml
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: build/test-results.xml
       - name: Build standalone
         run: |
           cmake -B build-standalone -DBUILD_STANDALONE=ON

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,3 +90,43 @@ target_link_libraries(test_identity PRIVATE
 )
 
 add_test(NAME test_identity COMMAND test_identity)
+
+# ── Module wiring tests ──────────────────────────────────────────────────────
+
+add_executable(test_module
+    test_module.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/calendar_module.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/calendar_sync.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/calendar_store.cpp
+)
+
+target_include_directories(test_module PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+target_link_libraries(test_module PRIVATE
+    Qt6::Core
+    Qt6::Test
+)
+
+add_test(NAME test_module COMMAND test_module)
+
+# ── Namespace isolation tests ─────────────────────────────────────────────────
+
+add_executable(test_namespace
+    test_namespace.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/calendar_store.cpp
+)
+
+target_include_directories(test_namespace PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+target_link_libraries(test_namespace PRIVATE
+    Qt6::Core
+    Qt6::Test
+)
+
+add_test(NAME test_namespace COMMAND test_namespace)

--- a/tests/test_module.cpp
+++ b/tests/test_module.cpp
@@ -1,0 +1,98 @@
+#include <QtTest>
+#include "../src/calendar_module.h"
+
+class TestModule : public QObject {
+    Q_OBJECT
+private slots:
+    void initTestCase() {}
+    void cleanupTestCase() {}
+
+    void createAndListCalendar();
+    void createAndListEvent();
+    void updateEvent();
+    void deleteEvent();
+    void generateShareLink();
+};
+
+void TestModule::createAndListCalendar() {
+    LogosCalendar module;
+    // createCalendar returns just the calendar ID
+    QString calId = module.createCalendar("Work", "#3b82f6");
+    QVERIFY(!calId.isEmpty());
+
+    QString list = module.listCalendars();
+    auto arr = QJsonDocument::fromJson(list.toUtf8()).array();
+    QCOMPARE(arr.size(), 1);
+    QCOMPARE(arr[0].toObject()["name"].toString(), QString("Work"));
+    QCOMPARE(arr[0].toObject()["color"].toString(), QString("#3b82f6"));
+    QCOMPARE(arr[0].toObject()["id"].toString(), calId);
+}
+
+void TestModule::createAndListEvent() {
+    LogosCalendar module;
+    QString calId = module.createCalendar("Work", "#3b82f6");
+
+    QJsonObject ev;
+    ev["title"] = "Standup";
+    ev["date"] = "2026-03-10";
+    ev["startTime"] = "09:00";
+    ev["endTime"] = "09:30";
+    // createEvent returns the event ID
+    QString eventId = module.createEvent(calId, QJsonDocument(ev).toJson(QJsonDocument::Compact));
+    QVERIFY(!eventId.isEmpty());
+
+    QString events = module.listEvents(calId);
+    auto arr = QJsonDocument::fromJson(events.toUtf8()).array();
+    QCOMPARE(arr.size(), 1);
+    QCOMPARE(arr[0].toObject()["title"].toString(), QString("Standup"));
+}
+
+void TestModule::updateEvent() {
+    LogosCalendar module;
+    QString calId = module.createCalendar("Work", "#3b82f6");
+
+    QJsonObject ev;
+    ev["title"] = "Standup";
+    ev["date"] = "2026-03-10";
+    module.createEvent(calId, QJsonDocument(ev).toJson(QJsonDocument::Compact));
+
+    QString events = module.listEvents(calId);
+    QJsonObject created = QJsonDocument::fromJson(events.toUtf8()).array()[0].toObject();
+    created["title"] = "Standup Updated";
+    // updateEvent takes only the event JSON (calendarId is already in the object)
+    module.updateEvent(QJsonDocument(created).toJson(QJsonDocument::Compact));
+
+    QString updated = module.listEvents(calId);
+    QCOMPARE(QJsonDocument::fromJson(updated.toUtf8()).array()[0].toObject()["title"].toString(),
+             QString("Standup Updated"));
+}
+
+void TestModule::deleteEvent() {
+    LogosCalendar module;
+    QString calId = module.createCalendar("Work", "#3b82f6");
+
+    QJsonObject ev;
+    ev["title"] = "To Delete";
+    ev["date"] = "2026-03-10";
+    module.createEvent(calId, QJsonDocument(ev).toJson(QJsonDocument::Compact));
+
+    QString events = module.listEvents(calId);
+    QString eventId = QJsonDocument::fromJson(events.toUtf8()).array()[0].toObject()["id"].toString();
+    // deleteEvent takes only the event ID
+    module.deleteEvent(eventId);
+
+    QString after = module.listEvents(calId);
+    QCOMPARE(QJsonDocument::fromJson(after.toUtf8()).array().size(), 0);
+}
+
+void TestModule::generateShareLink() {
+    LogosCalendar module;
+    QString calId = module.createCalendar("Shared", "#f59e0b");
+
+    QString link = module.generateShareLink(calId);
+    QVERIFY(!link.isEmpty());
+    QVERIFY(link.startsWith("scala://"));
+}
+
+QTEST_MAIN(TestModule)
+#include "test_module.moc"

--- a/tests/test_namespace.cpp
+++ b/tests/test_namespace.cpp
@@ -1,0 +1,49 @@
+#include <QtTest>
+#include "../src/calendar_store.h"
+
+class TestNamespace : public QObject {
+    Q_OBJECT
+private slots:
+    void isolationBetweenNamespaces();
+    void defaultNamespaceIsDefault();
+    void sameNamespaceSharesData();
+};
+
+void TestNamespace::isolationBetweenNamespaces() {
+    // Use a single store instance since in-memory map is per-instance
+    CalendarStore store;
+
+    store.setNamespace("alice");
+    store.kvSet("mykey", "alice-value");
+
+    // Switch to bob — should NOT see alice's data
+    store.setNamespace("bob");
+    QCOMPARE(store.kvGet("mykey"), QString());
+
+    // Switch back to alice — should still see it
+    store.setNamespace("alice");
+    QCOMPARE(store.kvGet("mykey"), QString("alice-value"));
+}
+
+void TestNamespace::defaultNamespaceIsDefault() {
+    CalendarStore store;
+    // Default namespace is "default" — write without calling setNamespace
+    store.kvSet("key", "hello");
+
+    // Explicitly set to "default" — should see the same data
+    store.setNamespace("default");
+    QCOMPARE(store.kvGet("key"), QString("hello"));
+}
+
+void TestNamespace::sameNamespaceSharesData() {
+    CalendarStore store;
+    store.setNamespace("shared");
+    store.kvSet("key", "value");
+
+    // Re-set same namespace — data should persist
+    store.setNamespace("shared");
+    QCOMPARE(store.kvGet("key"), QString("value"));
+}
+
+QTEST_MAIN(TestNamespace)
+#include "test_namespace.moc"


### PR DESCRIPTION
Closes #38, #39, #42.

## Changes
- **test_module.cpp**: CalendarModule CRUD round-trip tests (create/list calendar, create/list/update/delete event, share link generation)
- **test_namespace.cpp**: namespace isolation tests (cross-namespace isolation, default namespace equivalence, same-namespace persistence)
- **CI**: add missing Qt6 deps (`qt6-remoteobjects-dev`, `xvfb`), enable `BUILD_TESTS=ON`, junit test result upload

## Test plan
- [x] All 6 tests pass locally (4 existing + 2 new)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)