### PR TITLE
feat: separate My Calendars vs Imported in sidebar

### DIFF
--- a/qml/CalendarSidebar.qml
+++ b/qml/CalendarSidebar.qml
@@ -15,22 +15,126 @@ Rectangle {
     property color newBtnColor: "#4CAF50"
 
     // ── Data ───────────────────────────────────────────────────────────────
-    property alias calendarModel: calendarList.model
+    property var calendarModel: null
+    property string currentIdentity: ""
 
     signal calendarToggled(string calendarId, bool visible)
     signal newCalendarRequested()
     signal calendarSelected(string calendarId)
     signal shareRequested(string calendarId, string calendarName)
 
+    // ── Filter helpers ───────────────────────────────────────────────────
+    function myCalendars() {
+        var result = []
+        if (!calendarModel) return result
+        for (var i = 0; i < calendarModel.count; i++) {
+            var item = calendarModel.get(i)
+            if (item.creatorId === currentIdentity && currentIdentity !== "") {
+                result.push(item)
+            }
+        }
+        return result
+    }
+
+    function importedCalendars() {
+        var result = []
+        if (!calendarModel) return result
+        for (var i = 0; i < calendarModel.count; i++) {
+            var item = calendarModel.get(i)
+            if (item.creatorId !== currentIdentity || currentIdentity === "") {
+                result.push(item)
+            }
+        }
+        return result
+    }
+
     // ── Default calendars (mock) ───────────────────────────────────────────
     ListModel {
         id: defaultModel
         ListElement { calId: "personal"; calName: "Personal";
-                      calColor: "#4CAF50"; calVisible: true }
+                      calColor: "#4CAF50"; calVisible: true; creatorId: "" }
         ListElement { calId: "work";     calName: "Work";
-                      calColor: "#2196F3"; calVisible: true }
+                      calColor: "#2196F3"; calVisible: true; creatorId: "" }
         ListElement { calId: "family";   calName: "Family";
-                      calColor: "#FF9800"; calVisible: true }
+                      calColor: "#FF9800"; calVisible: true; creatorId: "" }
+    }
+
+    // Use defaultModel as fallback when no calendarModel is set
+    Component.onCompleted: {
+        if (!calendarModel) calendarModel = defaultModel
+    }
+
+    // ── Calendar delegate component ──────────────────────────────────────
+    Component {
+        id: calendarDelegate
+
+        Rectangle {
+            width: parent ? parent.width : 200
+            height: 40
+            radius: 6
+            color: delMouse.containsMouse ? "#f0f0f0" : "transparent"
+
+            property string itemCalId
+            property string itemCalName
+            property string itemCalColor
+            property bool itemCalVisible
+
+            MouseArea {
+                id: delMouse
+                anchors.fill: parent
+                hoverEnabled: true
+                onClicked: calendarSelected(itemCalId)
+            }
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 8
+                anchors.rightMargin: 8
+                spacing: 8
+
+                // Color indicator
+                Rectangle {
+                    width: 12
+                    height: 12
+                    radius: 6
+                    color: itemCalColor
+                }
+
+                // Calendar name
+                Text {
+                    text: itemCalName
+                    font.pixelSize: 14
+                    color: titleColor
+                    elide: Text.ElideRight
+                    Layout.fillWidth: true
+                }
+
+                // Share button
+                Button {
+                    implicitWidth: 28
+                    implicitHeight: 28
+                    flat: true
+                    text: "\u21AA"
+                    font.pixelSize: 14
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Share"
+                    onClicked: shareRequested(itemCalId, itemCalName)
+
+                    background: Rectangle {
+                        radius: 4
+                        color: parent.hovered ? "#e3f2fd" : "transparent"
+                    }
+                }
+
+                // Visibility toggle
+                CheckBox {
+                    checked: itemCalVisible
+                    onToggled: {
+                        calendarToggled(itemCalId, checked)
+                    }
+                }
+            }
+        }
     }
 
     ColumnLayout {
@@ -52,74 +156,97 @@ Rectangle {
             color: "#e0e0e0"
         }
 
-        // ── Calendar list ──────────────────────────────────────────────────
-        ListView {
-            id: calendarList
+        // ── Scrollable calendar sections ─────────────────────────────────
+        Flickable {
             Layout.fillWidth: true
             Layout.fillHeight: true
-            model: defaultModel
-            spacing: 2
+            contentHeight: sectionsColumn.height
             clip: true
+            boundsBehavior: Flickable.StopAtBounds
 
-            delegate: Rectangle {
-                width: calendarList.width
-                height: 40
-                radius: 6
-                color: delegateMouse.containsMouse ? "#f0f0f0" : "transparent"
+            Column {
+                id: sectionsColumn
+                width: parent.width
+                spacing: 8
 
-                MouseArea {
-                    id: delegateMouse
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    onClicked: calendarSelected(calId)
-                }
+                // ── My Calendars section ─────────────────────────────────
+                Column {
+                    width: parent.width
+                    spacing: 2
 
-                RowLayout {
-                    anchors.fill: parent
-                    anchors.leftMargin: 8
-                    anchors.rightMargin: 8
-                    spacing: 8
-
-                    // Color indicator
-                    Rectangle {
-                        width: 12
-                        height: 12
-                        radius: 6
-                        color: calColor
-                    }
-
-                    // Calendar name
                     Text {
-                        text: calName
-                        font.pixelSize: 14
-                        color: titleColor
-                        elide: Text.ElideRight
-                        Layout.fillWidth: true
+                        text: "My Calendars"
+                        font.pixelSize: 12
+                        font.bold: true
+                        color: subtitleColor
+                        leftPadding: 4
+                        topPadding: 4
+                        bottomPadding: 4
                     }
 
-                    // Share button
-                    Button {
-                        implicitWidth: 28
-                        implicitHeight: 28
-                        flat: true
-                        text: "\u21AA"
-                        font.pixelSize: 14
-                        ToolTip.visible: hovered
-                        ToolTip.text: "Share"
-                        onClicked: shareRequested(calId, calName)
+                    Repeater {
+                        model: myCalendars()
 
-                        background: Rectangle {
-                            radius: 4
-                            color: parent.hovered ? "#e3f2fd" : "transparent"
+                        delegate: Loader {
+                            width: sectionsColumn.width
+                            sourceComponent: calendarDelegate
+                            onLoaded: {
+                                item.itemCalId = modelData.calId
+                                item.itemCalName = modelData.calName
+                                item.itemCalColor = modelData.calColor
+                                item.itemCalVisible = modelData.calVisible
+                            }
                         }
                     }
 
-                    // Visibility toggle
-                    CheckBox {
-                        checked: calVisible
-                        onToggled: {
-                            calVisible = checked;
-                            calendarToggled(calId, checked);
+                    // Empty state
+                    Text {
+                        visible: myCalendars().length === 0
+                        text: "No calendars yet"
+                        font.pixelSize: 12
+                        font.italic: true
+                        color: "#aaa"
+                        leftPadding: 8
+                        topPadding: 4
+                    }
+                }
+
+                // ── Divider ──────────────────────────────────────────────
+                Rectangle {
+                    width: parent.width
+                    height: 1
+                    color: "#e0e0e0"
+                    visible: importedCalendars().length > 0
+                }
+
+                // ── Imported section ─────────────────────────────────────
+                Column {
+                    width: parent.width
+                    spacing: 2
+                    visible: importedCalendars().length > 0
+
+                    Text {
+                        text: "Imported"
+                        font.pixelSize: 12
+                        font.bold: true
+                        color: subtitleColor
+                        leftPadding: 4
+                        topPadding: 4
+                        bottomPadding: 4
+                    }
+
+                    Repeater {
+                        model: importedCalendars()
+
+                        delegate: Loader {
+                            width: sectionsColumn.width
+                            sourceComponent: calendarDelegate
+                            onLoaded: {
+                                item.itemCalId = modelData.calId
+                                item.itemCalName = modelData.calName
+                                item.itemCalColor = modelData.calColor
+                                item.itemCalVisible = modelData.calVisible
+                            }
                         }
                     }
                 }

--- a/qml/CalendarView.qml
+++ b/qml/CalendarView.qml
@@ -52,7 +52,8 @@ Item {
                 calId: c.id,
                 calName: c.name,
                 calColor: c.color,
-                calVisible: true
+                calVisible: true,
+                creatorId: c.creatorId || ""
             })
         }
     }
@@ -178,6 +179,7 @@ Item {
             Layout.preferredWidth: 220
             Layout.fillHeight: true
             calendarModel: sidebarCalendarModel
+            currentIdentity: typeof calendarModule !== "undefined" ? calendarModule.getIdentity() : ""
 
             onCalendarToggled: function(calId, vis) {
                 console.log("Calendar toggled:", calId, vis);

--- a/src/calendar_module.cpp
+++ b/src/calendar_module.cpp
@@ -126,6 +126,7 @@ QString LogosCalendar::createCalendar(const QString &name, const QString &color)
     cal.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
     cal.name = name;
     cal.color = color;
+    cal.creatorId = m_identity;
     cal.isShared = false;
     qint64 now = QDateTime::currentMSecsSinceEpoch();
     cal.createdAt = now;

--- a/src/types.h
+++ b/src/types.h
@@ -68,6 +68,7 @@ struct Calendar {
     QString id;
     QString name;
     QString color;
+    QString creatorId;
     bool isShared = false;
     QString encryptionKey;
     qint64 createdAt = 0;
@@ -78,6 +79,7 @@ struct Calendar {
         obj["id"] = id;
         obj["name"] = name;
         obj["color"] = color;
+        obj["creatorId"] = creatorId;
         obj["isShared"] = isShared;
         obj["encryptionKey"] = encryptionKey;
         obj["createdAt"] = createdAt;
@@ -90,6 +92,7 @@ struct Calendar {
         cal.id = obj["id"].toString();
         cal.name = obj["name"].toString();
         cal.color = obj["color"].toString();
+        cal.creatorId = obj["creatorId"].toString();
         cal.isShared = obj["isShared"].toBool();
         cal.encryptionKey = obj["encryptionKey"].toString();
         cal.createdAt = static_cast<qint64>(obj["createdAt"].toDouble());


### PR DESCRIPTION
Closes #25.

Sidebar now shows two sections: My Calendars (owned by current identity) and Imported (joined via share link).

## Summary
- Added `creatorId` field to `Calendar` struct in `types.h` with JSON serialization
- Set `creatorId = m_identity` when creating calendars in `calendar_module.cpp`
- Restructured `CalendarSidebar.qml` to display two sections:
  - **My Calendars**: calendars where `creatorId` matches current identity
  - **Imported**: calendars where `creatorId` is empty or belongs to someone else
- Updated `CalendarView.qml` to pass `currentIdentity` and `creatorId` to sidebar model

## Test plan
- [ ] Create a new calendar and verify it appears under "My Calendars"
- [ ] Import a calendar via share link and verify it appears under "Imported"
- [ ] Verify share buttons and visibility toggles still work in both sections
- [ ] Verify empty state text appears when no calendars exist in a section

🤖 Generated with [Claude Code](https://claude.com/claude-code)