### PR TITLE
feat: settings panel — default view, first day, identity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ if(BUILD_STANDALONE)
             qml/EventModal.qml
             qml/EventDetails.qml
             qml/ShareDialog.qml
+            qml/SettingsPanel.qml
         RESOURCE_PREFIX "/ScalaApp"
     )
 

--- a/module.yaml
+++ b/module.yaml
@@ -19,6 +19,7 @@ qml_files:
   - qml/EventModal.qml
   - qml/EventDetails.qml
   - qml/ShareDialog.qml
+  - qml/SettingsPanel.qml
 
 nix_packages:
   build: []

--- a/qml/CalendarView.qml
+++ b/qml/CalendarView.qml
@@ -167,6 +167,12 @@ Item {
     Component.onCompleted: {
         refreshCalendars()
         refreshEvents()
+        // Load settings
+        if (typeof calendarModule !== "undefined") {
+            var dv = calendarModule.getSetting("defaultView", "month")
+            if (dv === "month" || dv === "week" || dv === "day")
+                viewMode = dv
+        }
     }
 
     RowLayout {
@@ -293,6 +299,30 @@ Item {
                             color: "white"
                             font.pixelSize: 14
                             font.bold: true
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                    }
+
+                    Item { width: 4 }
+
+                    // Settings button
+                    Button {
+                        text: "\u2699"
+                        flat: true
+                        onClicked: settingsPanel.open()
+                        implicitWidth: 36
+                        implicitHeight: 36
+                        ToolTip.visible: hovered
+                        ToolTip.text: "Settings"
+                        background: Rectangle {
+                            radius: 4
+                            color: parent.hovered ? "#1976D2" : "transparent"
+                        }
+                        contentItem: Text {
+                            text: parent.text
+                            color: "white"
+                            font.pixelSize: 18
                             horizontalAlignment: Text.AlignHCenter
                             verticalAlignment: Text.AlignVCenter
                         }
@@ -753,6 +783,20 @@ Item {
                 refreshEvents()
                 calendarGrid.events = eventsForGrid()
                 shareDialog.close()
+            }
+        }
+    }
+
+    // ── Settings panel ───────────────────────────────────────────────────
+    SettingsPanel {
+        id: settingsPanel
+
+        onSettingsSaved: {
+            // Apply default view setting
+            if (typeof calendarModule !== "undefined") {
+                var dv = calendarModule.getSetting("defaultView", "month")
+                if (dv === "month" || dv === "week" || dv === "day")
+                    viewMode = dv
             }
         }
     }

--- a/qml/SettingsPanel.qml
+++ b/qml/SettingsPanel.qml
@@ -1,0 +1,292 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Popup {
+    id: root
+    modal: true
+    focus: true
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+    anchors.centerIn: parent
+    width: Math.min(parent.width - 40, 420)
+    height: Math.min(parent.height - 40, 480)
+    padding: 0
+
+    // ── Theme ──────────────────────────────────────────────────────────────
+    property color headerColor: "#2196F3"
+    property color fieldBg: "#f5f5f5"
+    property color fieldBorder: "#e0e0e0"
+    property color saveBtnColor: "#4CAF50"
+
+    signal settingsSaved()
+
+    function loadSettings() {
+        if (typeof calendarModule === "undefined") return
+        var dv = calendarModule.getSetting("defaultView", "month")
+        if (dv === "week") defaultViewCombo.currentIndex = 1
+        else if (dv === "day") defaultViewCombo.currentIndex = 2
+        else defaultViewCombo.currentIndex = 0
+
+        var fdow = calendarModule.getSetting("firstDayOfWeek", "monday")
+        firstDayCombo.currentIndex = fdow === "sunday" ? 1 : 0
+
+        var showDeclined = calendarModule.getSetting("showDeclinedEvents", "false")
+        showDeclinedSwitch.checked = showDeclined === "true"
+
+        identityField.text = calendarModule.getIdentity()
+    }
+
+    function saveSettings() {
+        if (typeof calendarModule === "undefined") return
+        var views = ["month", "week", "day"]
+        calendarModule.setSetting("defaultView", views[defaultViewCombo.currentIndex])
+
+        var days = ["monday", "sunday"]
+        calendarModule.setSetting("firstDayOfWeek", days[firstDayCombo.currentIndex])
+
+        calendarModule.setSetting("showDeclinedEvents",
+            showDeclinedSwitch.checked ? "true" : "false")
+
+        settingsSaved()
+    }
+
+    onOpened: loadSettings()
+
+    background: Rectangle {
+        radius: 8
+        color: "white"
+        border.color: "#e0e0e0"
+    }
+
+    contentItem: ColumnLayout {
+        spacing: 0
+
+        // ── Header ─────────────────────────────────────────────────────────
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 48
+            color: headerColor
+            radius: 8
+
+            Rectangle {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: 8
+                color: headerColor
+            }
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 16
+                anchors.rightMargin: 16
+
+                Text {
+                    text: "Settings"
+                    color: "white"
+                    font.pixelSize: 18
+                    font.bold: true
+                }
+
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "X"
+                    flat: true
+                    onClicked: root.close()
+                    implicitWidth: 32
+                    implicitHeight: 32
+                    contentItem: Text {
+                        text: "X"
+                        color: "white"
+                        font.pixelSize: 16
+                        font.bold: true
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle { color: "transparent" }
+                }
+            }
+        }
+
+        // ── Settings form ─────────────────────────────────────────────────
+        Flickable {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            contentHeight: settingsColumn.implicitHeight
+            clip: true
+            boundsBehavior: Flickable.StopAtBounds
+
+            ColumnLayout {
+                id: settingsColumn
+                width: parent.width
+                spacing: 16
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: 20
+                anchors.rightMargin: 20
+                anchors.top: parent.top
+                anchors.topMargin: 16
+
+                // Default view
+                Text { text: "Default View"; font.pixelSize: 13; font.bold: true; color: "#333" }
+                ComboBox {
+                    id: defaultViewCombo
+                    Layout.fillWidth: true
+                    model: ["Month", "Week", "Day"]
+                    background: Rectangle {
+                        radius: 4; color: fieldBg; border.color: fieldBorder
+                    }
+                }
+
+                // Divider
+                Rectangle { Layout.fillWidth: true; height: 1; color: "#e0e0e0" }
+
+                // First day of week
+                Text { text: "First Day of Week"; font.pixelSize: 13; font.bold: true; color: "#333" }
+                ComboBox {
+                    id: firstDayCombo
+                    Layout.fillWidth: true
+                    model: ["Monday", "Sunday"]
+                    background: Rectangle {
+                        radius: 4; color: fieldBg; border.color: fieldBorder
+                    }
+                }
+
+                // Divider
+                Rectangle { Layout.fillWidth: true; height: 1; color: "#e0e0e0" }
+
+                // Show declined events
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 12
+                    Text {
+                        text: "Show Declined Events"
+                        font.pixelSize: 13
+                        font.bold: true
+                        color: "#333"
+                        Layout.fillWidth: true
+                    }
+                    Switch {
+                        id: showDeclinedSwitch
+                    }
+                }
+
+                // Divider
+                Rectangle { Layout.fillWidth: true; height: 1; color: "#e0e0e0" }
+
+                // Identity
+                Text { text: "Identity"; font.pixelSize: 13; font.bold: true; color: "#333" }
+                Text { text: "Your public key (read-only)"; font.pixelSize: 11; color: "#999" }
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    TextField {
+                        id: identityField
+                        Layout.fillWidth: true
+                        readOnly: true
+                        font.pixelSize: 12
+                        font.family: "monospace"
+                        selectByMouse: true
+                        background: Rectangle {
+                            radius: 4; color: "#eee"; border.color: fieldBorder
+                        }
+                    }
+
+                    Button {
+                        text: "Copy"
+                        implicitWidth: 60
+                        onClicked: {
+                            identityField.selectAll()
+                            identityField.copy()
+                            identityField.deselect()
+                            copyTooltip.visible = true
+                            copyTimer.restart()
+                        }
+                        background: Rectangle {
+                            radius: 4
+                            color: parent.hovered ? "#e3f2fd" : fieldBg
+                            border.color: fieldBorder
+                        }
+                        contentItem: Text {
+                            text: parent.text
+                            font.pixelSize: 12
+                            color: "#333"
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                        }
+
+                        ToolTip {
+                            id: copyTooltip
+                            text: "Copied!"
+                            visible: false
+                            delay: 0
+                            timeout: 1500
+                        }
+
+                        Timer {
+                            id: copyTimer
+                            interval: 1500
+                            onTriggered: copyTooltip.visible = false
+                        }
+                    }
+                }
+
+                Item { Layout.preferredHeight: 8 }
+            }
+        }
+
+        // ── Action buttons ─────────────────────────────────────────────────
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 56
+            color: "white"
+            border.color: "#eee"
+            border.width: 1
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.margins: 12
+                spacing: 8
+
+                Item { Layout.fillWidth: true }
+
+                Button {
+                    text: "Cancel"
+                    onClicked: root.close()
+                    background: Rectangle {
+                        radius: 6
+                        color: parent.hovered ? "#e0e0e0" : "#eeeeee"
+                    }
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 14
+                        color: "#555"
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                }
+
+                Button {
+                    text: "Save"
+                    onClicked: {
+                        saveSettings()
+                        root.close()
+                    }
+                    background: Rectangle {
+                        radius: 6
+                        color: parent.pressed ? Qt.darker(saveBtnColor, 1.2)
+                             : parent.hovered ? Qt.lighter(saveBtnColor, 1.1)
+                             : saveBtnColor
+                    }
+                    contentItem: Text {
+                        text: parent.text; font.pixelSize: 14; font.bold: true
+                        color: "white"
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/calendar_module.cpp
+++ b/src/calendar_module.cpp
@@ -431,6 +431,17 @@ bool LogosCalendar::handleShareLink(const QString &link) {
     return joinSharedCalendar(id, key);
 }
 
+// ── Settings API ─────────────────────────────────────────────────────────────
+
+void LogosCalendar::setSetting(const QString &key, const QString &value) {
+    m_store.kvSet(QStringLiteral("setting_") + key, value);
+}
+
+QString LogosCalendar::getSetting(const QString &key, const QString &defaultValue) {
+    QString val = m_store.kvGet(QStringLiteral("setting_") + key);
+    return val.isEmpty() ? defaultValue : val;
+}
+
 // ── Incoming sync messages ───────────────────────────────────────────────────
 
 void LogosCalendar::onSyncMessageReceived(const QString &calendarId,

--- a/src/calendar_module.h
+++ b/src/calendar_module.h
@@ -106,6 +106,10 @@ public:
     Q_INVOKABLE QString parseShareLink(const QString &link) override;
     Q_INVOKABLE bool handleShareLink(const QString &link) override;
 
+    // ── Settings API ─────────────────────────────────────────────────────
+    Q_INVOKABLE void setSetting(const QString &key, const QString &value);
+    Q_INVOKABLE QString getSetting(const QString &key, const QString &defaultValue = QString());
+
 signals:
     void eventResponse(const QString &eventName, const QVariantList &args);
     void syncStatusChanged(const QString &calendarId, const QString &status);


### PR DESCRIPTION
Closes #26.

Adds a settings panel with default view preference, first day of week, and identity display.

## Summary
- **C++ backend**: Added `setSetting(key, value)` and `getSetting(key, defaultValue)` Q_INVOKABLE methods to `LogosCalendar`, stored via KV with `setting_` prefix
- **SettingsPanel.qml**: New popup panel with:
  - **Default view**: dropdown for Month/Week/Day
  - **First day of week**: Monday or Sunday
  - **Show declined events**: toggle switch
  - **Identity**: read-only text field showing public key with Copy button
- **Toolbar**: Added gear icon (⚙) button to open settings
- **Startup**: Loads `defaultView` setting and applies it on `Component.onCompleted`
- **On save**: Applies default view setting immediately
- Registered `SettingsPanel.qml` in CMakeLists.txt and module.yaml

## Test plan
- [ ] Click gear icon in toolbar to open settings panel
- [ ] Change default view to Week, save, and verify the view switches
- [ ] Close and reopen the app — verify default view persists
- [ ] Verify identity key is displayed and Copy button works
- [ ] Toggle "Show declined events" and verify it saves
- [ ] Change first day of week and verify it persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)