### PR TITLE
feat: event reminders and system notifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ install(FILES ${CMAKE_SOURCE_DIR}/metadata.json
 # ── Standalone runner ────────────────────────────────────────────────────────
 option(BUILD_STANDALONE "Build standalone runner" OFF)
 if(BUILD_STANDALONE)
-    find_package(Qt6 REQUIRED COMPONENTS Quick Gui)
+    find_package(Qt6 REQUIRED COMPONENTS Quick Gui Widgets)
 
     qt_add_executable(scala_standalone standalone/main.cpp)
 
@@ -124,7 +124,7 @@ if(BUILD_STANDALONE)
     )
 
     target_link_libraries(scala_standalone PRIVATE
-        Qt6::Quick Qt6::Qml Qt6::Gui
+        Qt6::Quick Qt6::Qml Qt6::Gui Qt6::Widgets
     )
 endif()
 

--- a/qml/CalendarView.qml
+++ b/qml/CalendarView.qml
@@ -952,7 +952,8 @@ Item {
                 location: eventData.location,
                 startTime: msFromDateTime(eventData.startDate, eventData.startTime, true),
                 endTime: msFromDateTime(eventData.endDate, eventData.endTime, true),
-                allDay: eventData.allDay
+                allDay: eventData.allDay,
+                reminderMinutes: eventData.reminderMinutes !== undefined ? eventData.reminderMinutes : -1
             }
 
             if (eventData.id && eventData.id !== "") {

--- a/qml/EventModal.qml
+++ b/qml/EventModal.qml
@@ -66,6 +66,7 @@ Popup {
     }
     property string calendarId: ""
     property string eventId: ""
+    property int reminderMinutes: -1
     property var calendars: []
 
     signal saveClicked(var eventData)
@@ -79,6 +80,8 @@ Popup {
         mode = "create";
         eventId = "";
         calendarId = "";
+        reminderMinutes = -1;
+        reminderCombo.currentIndex = 0;
         calendarCombo.currentIndex = 0;
         _applyDate(startDate, startYearSpin, startMonthSpin, startDaySpin)
         _applyTime(startTime, startHourSpin, startMinuteSpin)
@@ -98,6 +101,15 @@ Popup {
         _applyTime(ev.startTime || "", startHourSpin, startMinuteSpin)
         _applyDate(ev.endDate || "", endYearSpin, endMonthSpin, endDaySpin)
         _applyTime(ev.endTime || "", endHourSpin, endMinuteSpin)
+        // Restore reminder setting
+        reminderMinutes = (ev.reminderMinutes !== undefined) ? ev.reminderMinutes : -1
+        var reminderOptions = [-1, 15, 30, 60]
+        for (var ri = 0; ri < reminderOptions.length; ri++) {
+            if (reminderOptions[ri] === reminderMinutes) {
+                reminderCombo.currentIndex = ri;
+                break;
+            }
+        }
         // Select the matching calendar in the combo
         for (var i = 0; i < calendars.length; i++) {
             if (calendars[i].id === calendarId) {
@@ -396,6 +408,19 @@ Popup {
                         radius: 4; color: fieldBg; border.color: fieldBorder
                     }
                 }
+
+                // Reminder
+                Text { text: "Reminder"; font.pixelSize: 13; color: "#555" }
+                ComboBox {
+                    id: reminderCombo
+                    Layout.fillWidth: true
+                    model: ["None", "15 minutes before", "30 minutes before", "1 hour before"]
+                    currentIndex: 0
+                    onCurrentIndexChanged: {
+                        var values = [-1, 15, 30, 60]
+                        reminderMinutes = values[currentIndex]
+                    }
+                }
             }
         }
 
@@ -444,7 +469,8 @@ Popup {
                             endDate: _dateStr(endYearSpin, endMonthSpin, endDaySpin),
                             endTime: _timeStr(endHourSpin, endMinuteSpin),
                             allDay: allDaySwitch.checked,
-                            calendarId: calendarId
+                            calendarId: calendarId,
+                            reminderMinutes: reminderMinutes
                         };
                         saveClicked(data);
                         root.close();

--- a/src/calendar_module.cpp
+++ b/src/calendar_module.cpp
@@ -432,6 +432,44 @@ bool LogosCalendar::handleShareLink(const QString &link) {
     return joinSharedCalendar(id, key);
 }
 
+// ── Reminders API ────────────────────────────────────────────────────────────
+
+QString LogosCalendar::getPendingReminders() {
+    QJsonArray pending;
+    QDateTime now = QDateTime::currentDateTime();
+
+    auto calendars = m_store.listCalendars();
+    for (const auto &cal : calendars) {
+        auto events = m_store.listEvents(cal.id);
+        for (const auto &ev : events) {
+            if (ev.reminderMinutes < 0)
+                continue;
+
+            // Check if already reminded
+            QString reminderKey = QStringLiteral("reminder:") + ev.id;
+            if (m_store.kvGet(reminderKey) == QStringLiteral("fired"))
+                continue;
+
+            // Check if event starts within the reminder window
+            qint64 msBefore = static_cast<qint64>(ev.reminderMinutes) * 60 * 1000;
+            QDateTime reminderTime = ev.startTime.addMSecs(-msBefore);
+            if (now >= reminderTime && now < ev.startTime) {
+                QJsonObject obj;
+                obj[QStringLiteral("id")] = ev.id;
+                obj[QStringLiteral("title")] = ev.title;
+                obj[QStringLiteral("startTime")] = ev.startTime.toMSecsSinceEpoch();
+                obj[QStringLiteral("calendarId")] = ev.calendarId;
+                pending.append(obj);
+
+                // Mark as fired
+                m_store.kvSet(reminderKey, QStringLiteral("fired"));
+            }
+        }
+    }
+
+    return QString::fromUtf8(QJsonDocument(pending).toJson(QJsonDocument::Compact));
+}
+
 // ── Settings API ─────────────────────────────────────────────────────────────
 
 void LogosCalendar::setSetting(const QString &key, const QString &value) {

--- a/src/calendar_module.h
+++ b/src/calendar_module.h
@@ -106,6 +106,9 @@ public:
     Q_INVOKABLE QString parseShareLink(const QString &link) override;
     Q_INVOKABLE bool handleShareLink(const QString &link) override;
 
+    // ── Reminders API ────────────────────────────────────────────────────
+    Q_INVOKABLE QString getPendingReminders();
+
     // ── Settings API ─────────────────────────────────────────────────────
     Q_INVOKABLE void setSetting(const QString &key, const QString &value);
     Q_INVOKABLE QString getSetting(const QString &key, const QString &defaultValue = QString());

--- a/src/types.h
+++ b/src/types.h
@@ -21,6 +21,7 @@ struct CalendarEvent {
     QString location;
     QStringList attendees;
     QString creatorId;
+    int reminderMinutes = -1;  // -1 = no reminder, 0/15/30/60 = minutes before
     qint64 createdAt = 0;
     qint64 updatedAt = 0;
 
@@ -39,6 +40,7 @@ struct CalendarEvent {
             att.append(a);
         obj["attendees"] = att;
         obj["creatorId"] = creatorId;
+        obj["reminderMinutes"] = reminderMinutes;
         obj["createdAt"] = createdAt;
         obj["updatedAt"] = updatedAt;
         return obj;
@@ -58,6 +60,7 @@ struct CalendarEvent {
         for (const auto &a : att)
             ev.attendees.append(a.toString());
         ev.creatorId = obj["creatorId"].toString();
+        ev.reminderMinutes = obj["reminderMinutes"].toInt(-1);
         ev.createdAt = static_cast<qint64>(obj["createdAt"].toDouble());
         ev.updatedAt = static_cast<qint64>(obj["updatedAt"].toDouble());
         return ev;

--- a/standalone/main.cpp
+++ b/standalone/main.cpp
@@ -1,11 +1,17 @@
-#include <QGuiApplication>
+#include <QApplication>
 #include <QQmlContext>
 #include <QQuickView>
+#include <QStyle>
+#include <QSystemTrayIcon>
+#include <QTimer>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 #include "calendar_module.h"
 
 int main(int argc, char *argv[]) {
-    QGuiApplication app(argc, argv);
+    QApplication app(argc, argv);
 
     // Software rendering for headless/no-GPU environments
     qputenv("QT_QUICK_BACKEND", "software");
@@ -14,6 +20,34 @@ int main(int argc, char *argv[]) {
     LogosCalendar module;
     module.setNamespace(qEnvironmentVariable("SCALA_NAMESPACE", "default"));
 
+    // ── System tray icon ─────────────────────────────────────────────────
+    QSystemTrayIcon trayIcon;
+    trayIcon.setIcon(QIcon::fromTheme(
+        QStringLiteral("x-office-calendar"),
+        app.style()->standardIcon(QStyle::SP_ComputerIcon)));
+    trayIcon.setToolTip(QStringLiteral("Scala Calendar"));
+    trayIcon.show();
+
+    // ── Reminder timer (every 60 seconds) ────────────────────────────────
+    QTimer reminderTimer;
+    QObject::connect(&reminderTimer, &QTimer::timeout, [&module, &trayIcon]() {
+        QString json = module.getPendingReminders();
+        QJsonArray reminders = QJsonDocument::fromJson(json.toUtf8()).array();
+        for (const auto &val : reminders) {
+            QJsonObject ev = val.toObject();
+            QString title = ev[QStringLiteral("title")].toString();
+            QDateTime start = QDateTime::fromMSecsSinceEpoch(
+                static_cast<qint64>(ev[QStringLiteral("startTime")].toDouble()));
+            QString timeStr = start.toString(QStringLiteral("hh:mm"));
+            trayIcon.showMessage(
+                QStringLiteral("Upcoming event"),
+                title + QStringLiteral(" at ") + timeStr,
+                QSystemTrayIcon::Information, 5000);
+        }
+    });
+    reminderTimer.start(60000);
+
+    // ── QML view ─────────────────────────────────────────────────────────
     QQuickView view;
     view.rootContext()->setContextProperty("calendarModule", &module);
     view.setResizeMode(QQuickView::SizeRootObjectToView);


### PR DESCRIPTION
Closes #30.

## Summary
- Adds `reminderMinutes` field to `CalendarEvent` with options: None, 15 min, 30 min, 1 hour before
- Adds `getPendingReminders()` method to the calendar module — scans all events, returns those within their reminder window, and marks them as fired in KV store
- Adds `QSystemTrayIcon` + `QTimer` (60s interval) to standalone mode — shows system tray notifications for upcoming events
- Adds reminder time selector ComboBox to the EventModal UI

## Test plan
- [ ] Build standalone: `cmake -B build-notif -DCMAKE_BUILD_TYPE=Debug -DBUILD_STANDALONE=ON && cmake --build build-notif -j$(nproc) --target scala_standalone`
- [ ] Create an event with a 15-minute reminder
- [ ] Verify system tray notification appears when within the reminder window
- [ ] Verify reminder only fires once (not on subsequent timer ticks)
- [ ] Edit an existing event and change/remove reminder setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)