### PR TITLE
feat: Scala CLI — shell wrapper for headless use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ NIX_QT_PREFIX  ?= $(NIX_QTBASE);$(NIX_QTDECL);$(NIX_QTREMOBJ)
 
 .PHONY: all build test clean standalone screenshot \
         setup setup-logoscore setup-kv-module \
-        run-core run dev
+        run-core run dev install-cli
 
 # ── Build ────────────────────────────────────────────────────────────────────
 
@@ -98,6 +98,12 @@ setup-kv-module: setup-nix-merged
 setup: setup-logoscore setup-kv-module
 	@echo ""
 	@echo "Setup complete! Run 'make dev' to start."
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+install-cli:
+	install -m 755 cli/scala-cli.sh ~/.local/bin/scala-cli
+	@echo "scala-cli installed to ~/.local/bin/scala-cli"
 
 # ── Run ──────────────────────────────────────────────────────────────────────
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,57 @@
+# Scala CLI
+
+A thin shell wrapper around `logoscore --call` for headless use of the Scala calendar module.
+
+## Prerequisites
+
+- `logoscore` binary (from [logos-liblogos](https://github.com/logos-co/logos-liblogos))
+- `kv_module` and `scala_module` plugins installed in the modules directory
+
+## Installation
+
+```bash
+make install-cli
+```
+
+This installs `scala-cli` to `~/.local/bin/`.
+
+## Usage
+
+```bash
+scala-cli <command> [args]
+```
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `list-calendars` | List all calendars |
+| `list-events <calId>` | List events for a calendar |
+| `create-calendar <name> <color>` | Create a new calendar |
+| `share <calId>` | Generate a share link |
+| `join <link>` | Join a shared calendar |
+| `identity` | Show current identity |
+
+### Examples
+
+```bash
+# List all calendars
+scala-cli list-calendars
+
+# Create a new calendar
+scala-cli create-calendar Work '#3b82f6'
+
+# List events for a calendar
+scala-cli list-events <calendar-id>
+
+# Share a calendar
+scala-cli share <calendar-id>
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SCALA_LOGOSCORE` | auto-detect | Path to `logoscore` binary |
+| `SCALA_MODULES_DIR` | `~/.local/share/logos/modules` | Modules directory |
+| `SCALA_NAMESPACE` | `default` | Namespace for data isolation |

--- a/cli/scala-cli.sh
+++ b/cli/scala-cli.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Scala CLI — wrapper around logoscore --call for headless use
+
+LOGOSCORE="${SCALA_LOGOSCORE:-$(which logoscore 2>/dev/null)}"
+MODULES_DIR="${SCALA_MODULES_DIR:-$HOME/.local/share/logos/modules}"
+NAMESPACE="${SCALA_NAMESPACE:-default}"
+
+if [ -z "$LOGOSCORE" ]; then
+    # Try nix store
+    LOGOSCORE=$(ls -d /nix/store/*logos-liblogos-bin-*/bin/logoscore 2>/dev/null | head -1)
+fi
+
+if [ -z "$LOGOSCORE" ]; then
+    echo "Error: logoscore not found. Set SCALA_LOGOSCORE or install logos-liblogos."
+    exit 1
+fi
+
+call() {
+    "$LOGOSCORE" --modules-dir "$MODULES_DIR" --load-modules kv_module,scala_module \
+        --call "scala_module.$1" 2>/dev/null | grep -v '^Debug'
+}
+
+case "$1" in
+    list-calendars)   call "listCalendars()" ;;
+    list-events)      call "listEvents($2)" ;;
+    create-calendar)  call "createCalendar($2,$3)" ;;
+    share)            call "generateShareLink($2)" ;;
+    join)             call "handleShareLink($2)" ;;
+    identity)         call "getIdentity()" ;;
+    help|--help|-h|"")
+        echo "Usage: scala-cli <command> [args]"
+        echo ""
+        echo "Commands:"
+        echo "  list-calendars           List all calendars"
+        echo "  list-events <calId>      List events for a calendar"
+        echo "  create-calendar <n> <c>  Create calendar (name, color)"
+        echo "  share <calId>            Generate share link"
+        echo "  join <link>              Join a shared calendar"
+        echo "  identity                 Show current identity"
+        ;;
+    *)
+        echo "Unknown command: $1. Run 'scala-cli help' for usage."
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Closes #43.

## Summary
- Adds `cli/scala-cli.sh` — a thin wrapper around `logoscore --call` that makes Scala module methods callable from the terminal
- Adds `cli/README.md` with usage documentation
- Adds `make install-cli` target to install the script to `~/.local/bin/`

```bash
scala-cli list-calendars
scala-cli create-calendar Work '#3b82f6'
scala-cli share <cal-id>
```

## Test plan
- [ ] Run `scala-cli help` and verify usage output
- [ ] Run `scala-cli list-calendars` with logoscore running
- [ ] Run `scala-cli create-calendar Test '#ff0000'` and verify calendar creation
- [ ] Run `make install-cli` and verify binary is installed
- [ ] Verify unknown commands show error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)